### PR TITLE
Throw subclass of Error instead of POJSO

### DIFF
--- a/resources/baseResource.ts
+++ b/resources/baseResource.ts
@@ -1,5 +1,5 @@
 import axiosStatic, { AxiosInstance } from "axios"
-import { UnitConfig, UnitError } from "../types/common"
+import { extractUnitError, UnitConfig, UnitError } from "../types/common"
 
 export class BaseResource {
     private resourcePath: string
@@ -27,7 +27,7 @@ export class BaseResource {
 
         return await this.axios.get<T | UnitError>(this.resourcePath + path, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
+            .catch<UnitError>(error => { throw extractUnitError(error) })
     }
 
     protected async httpPatch<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T> {
@@ -38,7 +38,7 @@ export class BaseResource {
 
         return await this.axios.patch<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
+            .catch<UnitError>(error => { throw extractUnitError(error) })
     }
 
     protected async httpPost<T>(path: string, data?: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T>{
@@ -49,7 +49,7 @@ export class BaseResource {
 
         return await this.axios.post<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
+            .catch<UnitError>(error => { throw extractUnitError(error) })
     }
 
     protected async httpPut<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T>{
@@ -60,13 +60,13 @@ export class BaseResource {
 
         return await this.axios.put<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
+            .catch<UnitError>(error => { throw extractUnitError(error) })
     }
 
     protected async httpDelete<T>(path: string) : Promise<UnitError | T> {
         return await this.axios.delete<T | UnitError>(this.resourcePath + path, {headers: this.headers})
             .then(r => r.data)
-            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
+            .catch<UnitError>(error => { throw extractUnitError(error) })
     }
 
     private mergeHeaders(configHeaders: object | undefined){

--- a/resources/baseResource.ts
+++ b/resources/baseResource.ts
@@ -27,7 +27,7 @@ export class BaseResource {
 
         return await this.axios.get<T | UnitError>(this.resourcePath + path, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw error.response.data as UnitError })
+            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
     }
 
     protected async httpPatch<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T> {
@@ -38,7 +38,7 @@ export class BaseResource {
 
         return await this.axios.patch<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw error.response.data as UnitError })
+            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
     }
 
     protected async httpPost<T>(path: string, data?: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T>{
@@ -49,7 +49,7 @@ export class BaseResource {
 
         return await this.axios.post<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw error.response.data as UnitError })
+            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
     }
 
     protected async httpPut<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T>{
@@ -60,13 +60,13 @@ export class BaseResource {
 
         return await this.axios.put<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw error.response.data as UnitError })
+            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
     }
 
     protected async httpDelete<T>(path: string) : Promise<UnitError | T> {
         return await this.axios.delete<T | UnitError>(this.resourcePath + path, {headers: this.headers})
             .then(r => r.data)
-            .catch<UnitError>(error => { throw error.response.data as UnitError })
+            .catch<UnitError>(error => { throw new UnitError(error.response.data) })
     }
 
     private mergeHeaders(configHeaders: object | undefined){

--- a/types/common.ts
+++ b/types/common.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance } from 'axios';
+import { AxiosInstance } from "axios"
 
 export type Status = "Approved" | "Denied" | "PendingReview"
 
@@ -302,12 +302,28 @@ export interface UnitConfig {
     axios?: AxiosInstance
 }
 
-export type UnitError = {
-    errors: [{
-        title: string
-        status: number
-        detail?: string
-        details?: string
-    }]
+export class UnitError extends Error {
+    // duck typing can be used as a last resort to determine the type of error thrown
+    public readonly isUnitError = true
+
+    // https://docs.unit.co/#intro-errors
+    public readonly errors: UnitErrorPayload[]
+
+    constructor(errors: UnitErrorPayload[] | UnitErrorPayload) {
+        super(Array.isArray(errors) ?  (errors.length === 1 ? errors[0].title : "Unit api client error") : errors.title)
+        // restore prototype chain; see:
+        // https://github.com/Microsoft/TypeScript/issues/13965#issuecomment-278570200
+        Object.setPrototypeOf(this, new.target.prototype)
+        this.name = "UnitError"
+
+        this.errors = Array.isArray(errors) ? errors : [errors]
+    }
 }
 
+export interface UnitErrorPayload {
+    title: string
+    status: number
+    code?: string
+    detail?: string
+    details?: string
+}

--- a/unit.ts
+++ b/unit.ts
@@ -61,7 +61,7 @@ export class Unit {
     }
 
     isError<T>(response: T | UnitError): response is UnitError {
-        return (response as UnitError).errors !== undefined
+        return (response as UnitError).isUnitError
     }
 }
 


### PR DESCRIPTION
This PR converts the `UnitError` object to a subclass of the Error object. 

While it is possible in JS to throw anything, it is generally considered bad practice. Please see discussions on [this stackoverflow thread](https://stackoverflow.com/a/11512623):  

> - Catching code may expect the thrown object to have the usual message, stacktrace, and name properties that appear on Errors.
> - Lack of a stacktrace makes debugging problematic, especially in the case of uncaught exceptions / unhandled rejections. E.g. Debugging an "Uncaught [Object object]" error can be particularly painful.
> 