### PR TITLE
Enable users to inject custom Axios instance

### DIFF
--- a/resources/account.ts
+++ b/resources/account.ts
@@ -1,13 +1,12 @@
-import { Include, UnitError, UnitResponse } from "../types/common"
+import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { CreateAccountRequest, Account, PatchAccountRequest, AccountLimits } from "../types/account"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Accounts extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/accounts", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/accounts", config)
     }
 
     public async create(request: CreateAccountRequest): Promise<UnitResponse<Account> | UnitError> {

--- a/resources/account.ts
+++ b/resources/account.ts
@@ -2,11 +2,12 @@ import { Include, UnitError, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { CreateAccountRequest, Account, PatchAccountRequest, AccountLimits } from "../types/account"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Accounts extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/accounts")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/accounts", axios)
     }
 
     public async create(request: CreateAccountRequest): Promise<UnitResponse<Account> | UnitError> {

--- a/resources/application.ts
+++ b/resources/application.ts
@@ -1,11 +1,12 @@
 import { Application, ApplicationDocument, CreateApplicationRequest, UploadDocumentRequest } from "../types/application"
 import { UnitResponse, Include, UnitError } from "../types/common"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Applications extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/applications")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/applications", axios)
     }
 
     public async list(params?: ApplicationListParams): Promise<UnitResponse<Application[]> | UnitError> {

--- a/resources/application.ts
+++ b/resources/application.ts
@@ -1,12 +1,11 @@
 import { Application, ApplicationDocument, CreateApplicationRequest, UploadDocumentRequest } from "../types/application"
-import { UnitResponse, Include, UnitError } from "../types/common"
+import { UnitResponse, Include, UnitError, UnitConfig } from "../types/common"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Applications extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/applications", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/applications", config)
     }
 
     public async list(params?: ApplicationListParams): Promise<UnitResponse<Application[]> | UnitError> {

--- a/resources/applicationForm.ts
+++ b/resources/applicationForm.ts
@@ -1,11 +1,10 @@
 import { BaseResource } from "./baseResource"
-import { UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { CreateApplicationFormRequest, CreateApplicationFormResponse } from "../types/applicationForm"
-import { AxiosInstance } from "axios"
 
 export class ApplicationForms extends BaseResource {
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/application-forms", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/application-forms", config)
     }
 
     public async create(request: CreateApplicationFormRequest) : Promise<UnitResponse<CreateApplicationFormResponse> | UnitError> {

--- a/resources/applicationForm.ts
+++ b/resources/applicationForm.ts
@@ -1,10 +1,11 @@
 import { BaseResource } from "./baseResource"
 import { UnitError, UnitResponse } from "../types/common"
 import { CreateApplicationFormRequest, CreateApplicationFormResponse } from "../types/applicationForm"
+import { AxiosInstance } from "axios"
 
 export class ApplicationForms extends BaseResource {
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/application-forms")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/application-forms", axios)
     }
 
     public async create(request: CreateApplicationFormRequest) : Promise<UnitResponse<CreateApplicationFormResponse> | UnitError> {

--- a/resources/authorization.ts
+++ b/resources/authorization.ts
@@ -1,11 +1,12 @@
 import { Authorization } from "../types/authorization"
 import { UnitResponse, UnitError } from "../types/common"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Authorizations extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/authorizations")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/authorizations", axios)
     }
 
     public async get(id: string): Promise<UnitResponse<Authorization> | UnitError> {

--- a/resources/authorization.ts
+++ b/resources/authorization.ts
@@ -1,12 +1,11 @@
 import { Authorization } from "../types/authorization"
-import { UnitResponse, UnitError } from "../types/common"
+import { UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Authorizations extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/authorizations", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/authorizations", config)
     }
 
     public async get(id: string): Promise<UnitResponse<Authorization> | UnitError> {

--- a/resources/baseResource.ts
+++ b/resources/baseResource.ts
@@ -1,17 +1,20 @@
-import axios from "axios"
+import axiosStatic, { AxiosInstance } from "axios"
 import { UnitError } from "../types/common"
 
 export class BaseResource {
     private resourcePath: string
     private headers: {}
+    private readonly axios: AxiosInstance
 
-    constructor(token: string, resourcePath: string) {
+    constructor(token: string, resourcePath: string, axios?: AxiosInstance) {
         this.resourcePath = resourcePath
 
         this.headers = {
             "Authorization": `Bearer ${token}`,
             "Content-Type": "application/vnd.api+json"
         }
+
+        this.axios = axios ?? axiosStatic
     }
 
     protected async httpGet<T>(path: string, config?: { headers?: object; params?: object; }) : Promise<UnitError | T> {
@@ -21,7 +24,7 @@ export class BaseResource {
             ...(config?.params && { params: (config.params)})
         }
 
-        return await axios.get<T | UnitError>(this.resourcePath + path, conf)
+        return await this.axios.get<T | UnitError>(this.resourcePath + path, conf)
             .then(r => r.data)
             .catch<UnitError>(error => { throw error.response.data as UnitError })
     }
@@ -32,7 +35,7 @@ export class BaseResource {
             ...(config?.params && { params: (config.params) })
         }
 
-        return await axios.patch<T | UnitError>(this.resourcePath + path, data, conf)
+        return await this.axios.patch<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
             .catch<UnitError>(error => { throw error.response.data as UnitError })
     }
@@ -43,7 +46,7 @@ export class BaseResource {
             ...(config?.params && { params: (config.params) })
         }
 
-        return await axios.post<T | UnitError>(this.resourcePath + path, data, conf)
+        return await this.axios.post<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
             .catch<UnitError>(error => { throw error.response.data as UnitError })
     }
@@ -54,13 +57,13 @@ export class BaseResource {
             ...(config?.params && { params: (config.params) })
         }
 
-        return await axios.put<T | UnitError>(this.resourcePath + path, data, conf)
+        return await this.axios.put<T | UnitError>(this.resourcePath + path, data, conf)
             .then(r => r.data)
             .catch<UnitError>(error => { throw error.response.data as UnitError })
     }
 
     protected async httpDelete<T>(path: string) : Promise<UnitError | T> {
-        return await axios.delete<T | UnitError>(this.resourcePath + path, {headers: this.headers})
+        return await this.axios.delete<T | UnitError>(this.resourcePath + path, {headers: this.headers})
             .then(r => r.data)
             .catch<UnitError>(error => { throw error.response.data as UnitError })
     }

--- a/resources/baseResource.ts
+++ b/resources/baseResource.ts
@@ -1,12 +1,12 @@
 import axiosStatic, { AxiosInstance } from "axios"
-import { UnitError } from "../types/common"
+import { UnitConfig, UnitError } from "../types/common"
 
 export class BaseResource {
     private resourcePath: string
     private headers: {}
     private readonly axios: AxiosInstance
 
-    constructor(token: string, resourcePath: string, axios?: AxiosInstance) {
+    constructor(token: string, resourcePath: string, config?: UnitConfig) {
         this.resourcePath = resourcePath
 
         this.headers = {
@@ -14,7 +14,7 @@ export class BaseResource {
             "Content-Type": "application/vnd.api+json"
         }
 
-        this.axios = axios ?? axiosStatic
+        this.axios = config?.axios ?? axiosStatic
     }
 
     protected async httpGet<T>(path: string, config?: { headers?: object; params?: object; }) : Promise<UnitError | T> {

--- a/resources/batchAccounts.ts
+++ b/resources/batchAccounts.ts
@@ -1,11 +1,10 @@
 import { BatchRelease } from "../types/batchAccount"
-import { Address,Relationship, UnitError, UnitResponse } from "../types/common"
+import { Address, Relationship, UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class BatchAccounts extends BaseResource {
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/batch-releases", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/batch-releases", config)
     }
 
     public async create(request: CraeteBatchReleaseRequest): Promise<UnitResponse<BatchRelease> | UnitError> {

--- a/resources/batchAccounts.ts
+++ b/resources/batchAccounts.ts
@@ -1,10 +1,11 @@
 import { BatchRelease } from "../types/batchAccount"
 import { Address,Relationship, UnitError, UnitResponse } from "../types/common"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class BatchAccounts extends BaseResource {
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/batch-releases")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/batch-releases", axios)
     }
 
     public async create(request: CraeteBatchReleaseRequest): Promise<UnitResponse<BatchRelease> | UnitError> {

--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -1,14 +1,13 @@
-import { CreateDebitCardRequest, Card, ReplaceCardRequest } from "../types/cards"
-import { UnitResponse, UnitError, Include } from "../types/common"
+import { Card, CreateDebitCardRequest, ReplaceCardRequest } from "../types/cards"
+import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Cards extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/cards", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/cards", config)
     }
 
     public async createDebitCard(request: CreateDebitCardRequest): Promise<UnitResponse<Card> | UnitError> {

--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -3,11 +3,12 @@ import { UnitResponse, UnitError, Include } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Cards extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/cards")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/cards", axios)
     }
 
     public async createDebitCard(request: CreateDebitCardRequest): Promise<UnitResponse<Card> | UnitError> {

--- a/resources/counterparty.ts
+++ b/resources/counterparty.ts
@@ -1,11 +1,12 @@
 import { UnitError, UnitResponse } from "../types/common"
 import { AchCounterparty, CreateCounterpartyRequest, PatchCounterpartyRequest } from "../types/counterparty"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Counterparties extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/counterparties")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/counterparties", axios)
     }
 
     public async create(request: CreateCounterpartyRequest): Promise<UnitResponse<AchCounterparty> | UnitError> {

--- a/resources/counterparty.ts
+++ b/resources/counterparty.ts
@@ -1,12 +1,11 @@
-import { UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { AchCounterparty, CreateCounterpartyRequest, PatchCounterpartyRequest } from "../types/counterparty"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Counterparties extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/counterparties", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/counterparties", config)
     }
 
     public async create(request: CreateCounterpartyRequest): Promise<UnitResponse<AchCounterparty> | UnitError> {

--- a/resources/customer.ts
+++ b/resources/customer.ts
@@ -1,12 +1,11 @@
-import { UnitResponse, UnitError} from "../types/common"
+import { UnitResponse, UnitError, UnitConfig } from "../types/common"
 import { Customer, PatchCustomerRequest } from "../types/customer"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Customers extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/customers", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/customers", config)
     }
 
     public async update(request: PatchCustomerRequest): Promise<UnitResponse<Customer> | UnitError>{

--- a/resources/customer.ts
+++ b/resources/customer.ts
@@ -1,11 +1,12 @@
 import { UnitResponse, UnitError} from "../types/common"
 import { Customer, PatchCustomerRequest } from "../types/customer"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Customers extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/customers")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/customers", axios)
     }
 
     public async update(request: PatchCustomerRequest): Promise<UnitResponse<Customer> | UnitError>{

--- a/resources/customerToken.ts
+++ b/resources/customerToken.ts
@@ -1,10 +1,11 @@
 import { UnitError, UnitResponse } from "../types/common"
 import { CreateTokenRequest, CustomerToken, CreateTokenVerificationRequest, VerificationToken } from "../types/customerToken"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class CustomerTokens extends BaseResource {
-    constructor(token: string, basePath: string){
-        super(token,basePath + "/customers")
+    constructor(token: string, basePath: string, axios?: AxiosInstance){
+        super(token,basePath + "/customers", axios)
     }
 
     public async createToken(customerId: string, request: CreateTokenRequest) : Promise<UnitResponse<CustomerToken> | UnitError> {

--- a/resources/customerToken.ts
+++ b/resources/customerToken.ts
@@ -1,11 +1,15 @@
-import { UnitError, UnitResponse } from "../types/common"
-import { CreateTokenRequest, CustomerToken, CreateTokenVerificationRequest, VerificationToken } from "../types/customerToken"
+import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import {
+    CreateTokenRequest,
+    CreateTokenVerificationRequest,
+    CustomerToken,
+    VerificationToken
+} from "../types/customerToken"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class CustomerTokens extends BaseResource {
-    constructor(token: string, basePath: string, axios?: AxiosInstance){
-        super(token,basePath + "/customers", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig){
+        super(token,basePath + "/customers", config)
     }
 
     public async createToken(customerId: string, request: CreateTokenRequest) : Promise<UnitResponse<CustomerToken> | UnitError> {

--- a/resources/events.ts
+++ b/resources/events.ts
@@ -1,11 +1,12 @@
 import { UnitResponse, UnitError } from "../types/common"
 import { UnitEvent } from "../types/events"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Events extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/events")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/events", axios)
     }
 
     public async get(id: string): Promise<UnitResponse<UnitEvent> | UnitError> {

--- a/resources/events.ts
+++ b/resources/events.ts
@@ -1,12 +1,11 @@
-import { UnitResponse, UnitError } from "../types/common"
+import { UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { UnitEvent } from "../types/events"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Events extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/events", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/events", config)
     }
 
     public async get(id: string): Promise<UnitResponse<UnitEvent> | UnitError> {

--- a/resources/fee.ts
+++ b/resources/fee.ts
@@ -1,10 +1,11 @@
 import { UnitResponse, UnitError } from "../types/common"
 import { CreateFeeRequest, Fee } from "../types/fee"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Fees extends BaseResource {
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/fees")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/fees", axios)
     }
 
     public async createFee(request: CreateFeeRequest): Promise<UnitResponse<Fee> | UnitError> {

--- a/resources/fee.ts
+++ b/resources/fee.ts
@@ -1,11 +1,10 @@
-import { UnitResponse, UnitError } from "../types/common"
+import { UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { CreateFeeRequest, Fee } from "../types/fee"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Fees extends BaseResource {
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/fees", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/fees", config)
     }
 
     public async createFee(request: CreateFeeRequest): Promise<UnitResponse<Fee> | UnitError> {

--- a/resources/payments.ts
+++ b/resources/payments.ts
@@ -1,14 +1,13 @@
 import { Account } from "../types/account"
-import { UnitResponse, UnitError, Include } from "../types/common"
+import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
-import { CreatePaymentRequest, Payment,AchPayment, PatchPaymentRequest } from "../types/payments"
+import { AchPayment, CreatePaymentRequest, PatchPaymentRequest, Payment } from "../types/payments"
 import { Transaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Payments extends BaseResource {
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/payments", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/payments", config)
     }
 
     public async create(request: CreatePaymentRequest) : Promise<UnitResponse<AchPayment> | UnitError> {

--- a/resources/payments.ts
+++ b/resources/payments.ts
@@ -4,10 +4,11 @@ import { Customer } from "../types/customer"
 import { CreatePaymentRequest, Payment,AchPayment, PatchPaymentRequest } from "../types/payments"
 import { Transaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Payments extends BaseResource {
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/payments")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/payments", axios)
     }
 
     public async create(request: CreatePaymentRequest) : Promise<UnitResponse<AchPayment> | UnitError> {

--- a/resources/statements.ts
+++ b/resources/statements.ts
@@ -1,9 +1,10 @@
 import { UnitResponse, Statement, UnitError } from "../types/common"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Statments extends BaseResource {
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/statements")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/statements", axios)
     }
 
     public async list(params?: StatementsListParams): Promise<UnitResponse<Statement[]> | UnitError> {

--- a/resources/statements.ts
+++ b/resources/statements.ts
@@ -1,10 +1,9 @@
-import { UnitResponse, Statement, UnitError } from "../types/common"
+import { Statement, UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Statments extends BaseResource {
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/statements", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/statements", config)
     }
 
     public async list(params?: StatementsListParams): Promise<UnitResponse<Statement[]> | UnitError> {

--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -1,14 +1,13 @@
-import { UnitError, Include, UnitResponse } from "../types/common"
+import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
 import { Transaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Transactions extends BaseResource {
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath, axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath, config)
     }
 
     /**

--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -3,11 +3,12 @@ import { Customer } from "../types/customer"
 import { Account } from "../types/account"
 import { Transaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Transactions extends BaseResource {
 
-    constructor(token: string, basePath: string) {
-        super(token, basePath)
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath, axios)
     }
 
     /**

--- a/resources/webhooks.ts
+++ b/resources/webhooks.ts
@@ -1,10 +1,11 @@
 import { UnitResponse, UnitError } from "../types/common"
 import { CreateWebhookRequest, PatchWebhookRequest, Webhook } from "../types/webhooks"
 import { BaseResource } from "./baseResource"
+import { AxiosInstance } from "axios"
 
 export class Webhooks extends BaseResource {
-    constructor(token: string, basePath: string) {
-        super(token, basePath + "/webhooks")
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+        super(token, basePath + "/webhooks", axios)
     }
 
     public async create(request: CreateWebhookRequest): Promise<UnitResponse<Webhook> | UnitError> {

--- a/resources/webhooks.ts
+++ b/resources/webhooks.ts
@@ -1,11 +1,10 @@
-import { UnitResponse, UnitError } from "../types/common"
+import { UnitConfig, UnitError, UnitResponse } from "../types/common"
 import { CreateWebhookRequest, PatchWebhookRequest, Webhook } from "../types/webhooks"
 import { BaseResource } from "./baseResource"
-import { AxiosInstance } from "axios"
 
 export class Webhooks extends BaseResource {
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
-        super(token, basePath + "/webhooks", axios)
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + "/webhooks", config)
     }
 
     public async create(request: CreateWebhookRequest): Promise<UnitResponse<Webhook> | UnitError> {

--- a/types/common.ts
+++ b/types/common.ts
@@ -1,3 +1,5 @@
+import { AxiosInstance } from 'axios';
+
 export type Status = "Approved" | "Denied" | "PendingReview"
 
 export type Title = "CEO" | "COO" | "CFO" | "President"
@@ -296,6 +298,10 @@ export interface Include<T> {
     included?: T
 }
 
+export interface UnitConfig {
+    axios?: AxiosInstance
+}
+
 export type UnitError = {
     errors: [{
         title: string
@@ -304,3 +310,4 @@ export type UnitError = {
         details?: string
     }]
 }
+

--- a/unit.ts
+++ b/unit.ts
@@ -5,7 +5,7 @@ import { Transactions } from "./resources/transactions"
 import { Accounts } from "./resources/account"
 import { CustomerTokens } from "./resources/customerToken"
 import { Webhooks } from "./resources/webhooks"
-import { UnitError } from "./types/common"
+import { UnitConfig, UnitError } from "./types/common"
 import { BatchAccounts } from "./resources/batchAccounts"
 import { Fees } from "./resources/fee"
 import * as helpers from "./helpers"
@@ -14,8 +14,7 @@ import { Events } from "./resources/events"
 import { Payments } from "./resources/payments"
 import { Authorizations } from "./resources/authorization"
 import { Statments } from "./resources/statements"
-import { ApplicationForms } from "./resources/applicationForm";
-import { AxiosInstance } from "axios"
+import { ApplicationForms } from "./resources/applicationForm"
 
 export class Unit {
     public applications: Applications
@@ -35,25 +34,26 @@ export class Unit {
     public events: Events
     public applicationForms: ApplicationForms
 
-    constructor(token: string, basePath: string, axios?: AxiosInstance) {
+    constructor(token: string, basePath: string, config?: UnitConfig) {
         // remove all trailing slashes from user-provided basePath
         basePath = basePath.trim().replace(/\/+$/, "")
 
-        this.applications = new Applications(token, basePath, axios)
-        this.customers = new Customers(token, basePath, axios)
-        this.accounts = new Accounts(token, basePath, axios)
-        this.transactions = new Transactions(token, basePath, axios)
-        this.cards = new Cards(token, basePath, axios)
-        this.webhooks = new Webhooks(token, basePath, axios)
-        this.customerToken = new CustomerTokens(token, basePath, axios)
-        this.batchAccount = new BatchAccounts(token, basePath, axios)
-        this.fees = new Fees(token, basePath, axios)
-        this.counterparties = new Counterparties(token, basePath, axios)
-        this.events = new Events(token, basePath, axios)
-        this.payments = new Payments(token, basePath, axios)
-        this.authorizations = new Authorizations(token, basePath, axios)
-        this.statements = new Statments(token, basePath, axios)
-        this.applicationForms = new ApplicationForms(token, basePath, axios)
+
+        this.applications = new Applications(token, basePath, config)
+        this.customers = new Customers(token, basePath, config)
+        this.accounts = new Accounts(token, basePath, config)
+        this.transactions = new Transactions(token, basePath, config)
+        this.cards = new Cards(token, basePath, config)
+        this.webhooks = new Webhooks(token, basePath, config)
+        this.customerToken = new CustomerTokens(token, basePath, config)
+        this.batchAccount = new BatchAccounts(token, basePath, config)
+        this.fees = new Fees(token, basePath, config)
+        this.counterparties = new Counterparties(token, basePath, config)
+        this.events = new Events(token, basePath, config)
+        this.payments = new Payments(token, basePath, config)
+        this.authorizations = new Authorizations(token, basePath, config)
+        this.statements = new Statments(token, basePath, config)
+        this.applicationForms = new ApplicationForms(token, basePath, config)
         this.helpers = helpers
     }
 

--- a/unit.ts
+++ b/unit.ts
@@ -1,4 +1,3 @@
-
 import { Applications } from "./resources/application"
 import { Cards } from "./resources/cards"
 import { Customers } from "./resources/customer"
@@ -16,6 +15,7 @@ import { Payments } from "./resources/payments"
 import { Authorizations } from "./resources/authorization"
 import { Statments } from "./resources/statements"
 import { ApplicationForms } from "./resources/applicationForm";
+import { AxiosInstance } from "axios"
 
 export class Unit {
     public applications: Applications
@@ -35,25 +35,25 @@ export class Unit {
     public events: Events
     public applicationForms: ApplicationForms
 
-    constructor(token: string, basePath: string) {
+    constructor(token: string, basePath: string, axios?: AxiosInstance) {
         // remove all trailing slashes from user-provided basePath
         basePath = basePath.trim().replace(/\/+$/, "")
 
-        this.applications = new Applications(token, basePath)
-        this.customers = new Customers(token, basePath)
-        this.accounts = new Accounts(token, basePath)
-        this.transactions = new Transactions(token, basePath)
-        this.cards = new Cards(token, basePath)
-        this.webhooks = new Webhooks(token, basePath)
-        this.customerToken = new CustomerTokens(token, basePath)
-        this.batchAccount = new BatchAccounts(token, basePath)
-        this.fees = new Fees(token, basePath)
-        this.counterparties = new Counterparties(token, basePath)
-        this.events = new Events(token, basePath)
-        this.payments = new Payments(token, basePath)
-        this.authorizations = new Authorizations(token, basePath)
-        this.statements = new Statments(token, basePath)
-        this.applicationForms = new ApplicationForms(token, basePath)
+        this.applications = new Applications(token, basePath, axios)
+        this.customers = new Customers(token, basePath, axios)
+        this.accounts = new Accounts(token, basePath, axios)
+        this.transactions = new Transactions(token, basePath, axios)
+        this.cards = new Cards(token, basePath, axios)
+        this.webhooks = new Webhooks(token, basePath, axios)
+        this.customerToken = new CustomerTokens(token, basePath, axios)
+        this.batchAccount = new BatchAccounts(token, basePath, axios)
+        this.fees = new Fees(token, basePath, axios)
+        this.counterparties = new Counterparties(token, basePath, axios)
+        this.events = new Events(token, basePath, axios)
+        this.payments = new Payments(token, basePath, axios)
+        this.authorizations = new Authorizations(token, basePath, axios)
+        this.statements = new Statments(token, basePath, axios)
+        this.applicationForms = new ApplicationForms(token, basePath, axios)
         this.helpers = helpers
     }
 


### PR DESCRIPTION
This may be a controversial idea, so please bear with me ...

At first glance, this seems like a bad idea, since it breaks encapsulation by leaking an API client implementation detail to the outside world. One of the several downsides of breaking encapsulation is that it may make it difficult to transparently migrate to a different http client (e.g. [got](https://github.com/sindresorhus/got)) in the future.

In the wild, we see several examples of API clients allowing users to provide their own instance of axios:
- [Segment's API client](https://github.com/segmentio/analytics-node/blob/3ec3f4212bfd4cc22f8bbe67dda13f337b7bb484/index.js#L41)
- [Plaid's new API client](https://github.com/plaid/plaid-node/blob/578c4e9f067fb1f76257c549829f5dc2d6e8e973/dist/base.js#L40) 

The reason this is done is so that the maintainer of the API does not have to provide observability (e.g. logging) and resilience (e.g. timeout, retry) services. Exposing the axios instance enables consumers to configure parameters on the instance itself (e.g. [timeout](https://github.com/axios/axios/issues/647#issuecomment-322209906)) and extend axios using off-the-shelf components like [axios-retry](https://www.npmjs.com/package/axios-retry), [axios-logger](https://www.npmjs.com/package/axios-logger), [axios-rate-limit](https://www.npmjs.com/package/axios-rate-limit), etc.