### PR TITLE
Remove trailing slashes from user-provided basePath

### DIFF
--- a/unit.ts
+++ b/unit.ts
@@ -34,6 +34,9 @@ export class Unit {
     public events: Events
 
     constructor(token: string, basePath: string) {
+        // remove all trailing slashes from user-provided basePath
+        basePath = basePath.trim().replace(/\/+$/, "")
+
         this.applications = new Applications(token, basePath)
         this.customers = new Customers(token, basePath)
         this.accounts = new Accounts(token, basePath)


### PR DESCRIPTION
Users of the client should be able to provide a `basePath` with a trailing slash.

The following are examples of how this will transform incoming `basePath` inputs: 
- `https://api.s.unit.sh` ⟶ `https://api.s.unit.sh`
- `https://api.s.unit.sh/` ⟶ `https://api.s.unit.sh`
- `https://api.s.unit.sh////` ⟶ `https://api.s.unit.sh`

One minor issue one may have with this implementation is that it's generally [considered bad practice to modify input arguments in the function body](https://stackoverflow.com/a/41260819), but in this case the author favored brevity over convention.