### PR TITLE
Remove UnitError from resource return types

### DIFF
--- a/resources/account.ts
+++ b/resources/account.ts
@@ -1,4 +1,4 @@
-import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { Include, UnitResponse, UnitConfig } from "../types/common"
 import { Customer } from "../types/customer"
 import { CreateAccountRequest, Account, PatchAccountRequest, AccountLimits } from "../types/account"
 import { BaseResource } from "./baseResource"
@@ -9,15 +9,15 @@ export class Accounts extends BaseResource {
         super(token, basePath + "/accounts", config)
     }
 
-    public async create(request: CreateAccountRequest): Promise<UnitResponse<Account> | UnitError> {
+    public async create(request: CreateAccountRequest): Promise<UnitResponse<Account>> {
         return this.httpPost<UnitResponse<Account>>("", { data: request })
     }
 
-    public async closeAccount(accountId: string): Promise<UnitResponse<Account> | UnitError> {
+    public async closeAccount(accountId: string): Promise<UnitResponse<Account>> {
         return this.httpPost<UnitResponse<Account>>(`/${accountId}/close`)
     }
 
-    public async reopenAccount(accountId: string): Promise<UnitResponse<Account> | UnitError> {
+    public async reopenAccount(accountId: string): Promise<UnitResponse<Account>> {
         return this.httpPost<UnitResponse<Account>>(`/${accountId}/reopen`)
     }
 
@@ -26,11 +26,11 @@ export class Accounts extends BaseResource {
      * @param id
      * @param include
      */
-    public async get(id: string, include = ""): Promise<UnitResponse<Account> & Include<Customer> | UnitError> {
+    public async get(id: string, include = ""): Promise<UnitResponse<Account> & Include<Customer>> {
         return this.httpGet<UnitResponse<Account> & Include<Customer>>(`/${id}`, { params: { include } })
     }
 
-    public async list(params?: AccountListParams): Promise<UnitResponse<Account> & Include<Customer> | UnitError> {
+    public async list(params?: AccountListParams): Promise<UnitResponse<Account> & Include<Customer>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -42,11 +42,11 @@ export class Accounts extends BaseResource {
         return this.httpGet<UnitResponse<Account> & Include<Customer>>("", { params: parameters })
     }
 
-    public async update(request: PatchAccountRequest) : Promise<UnitResponse<Account> | UnitError> {
-        return this.httpPatch<UnitResponse<Account> | UnitError>(`/${request.accountId}`,{data: request.data})
+    public async update(request: PatchAccountRequest) : Promise<UnitResponse<Account>> {
+        return this.httpPatch<UnitResponse<Account>>(`/${request.accountId}`,{data: request.data})
     }
 
-    public async limits(accountId: string) : Promise<UnitResponse<AccountLimits> | UnitError> {
+    public async limits(accountId: string) : Promise<UnitResponse<AccountLimits>> {
         return this.httpGet<UnitResponse<AccountLimits>>(`/${accountId}/limits`)
     }
 }

--- a/resources/application.ts
+++ b/resources/application.ts
@@ -1,5 +1,5 @@
 import { Application, ApplicationDocument, CreateApplicationRequest, UploadDocumentRequest } from "../types/application"
-import { UnitResponse, Include, UnitError, UnitConfig } from "../types/common"
+import { UnitResponse, Include, UnitConfig } from "../types/common"
 import { BaseResource } from "./baseResource"
 
 export class Applications extends BaseResource {
@@ -8,7 +8,7 @@ export class Applications extends BaseResource {
         super(token, basePath + "/applications", config)
     }
 
-    public async list(params?: ApplicationListParams): Promise<UnitResponse<Application[]> | UnitError> {
+    public async list(params?: ApplicationListParams): Promise<UnitResponse<Application[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -21,11 +21,11 @@ export class Applications extends BaseResource {
         return this.httpGet<UnitResponse<Application[]>>("", { params: parameters })
     }
 
-    public async create(request: CreateApplicationRequest): Promise<UnitResponse<Application> | UnitError> {
+    public async create(request: CreateApplicationRequest): Promise<UnitResponse<Application>> {
         return this.httpPost<UnitResponse<Application>>("", { data: request })
     }
 
-    public async upload(request: UploadDocumentRequest) : Promise<UnitResponse<ApplicationDocument> | UnitError> {
+    public async upload(request: UploadDocumentRequest) : Promise<UnitResponse<ApplicationDocument>> {
 
         let path = `/${request.applicationId}/documents/${request.documentId}`
         if (request.isBackSide)
@@ -56,11 +56,11 @@ export class Applications extends BaseResource {
         return this.httpPut<UnitResponse<ApplicationDocument>>(path, { data: request.file }, {headers})
     }
 
-    public async get(applicationId: string): Promise<UnitResponse<Application> & Include<ApplicationDocument[]> | UnitError> {
+    public async get(applicationId: string): Promise<UnitResponse<Application> & Include<ApplicationDocument[]>> {
         return this.httpGet<UnitResponse<Application> & Include<ApplicationDocument[]>>(`/${applicationId}`)
     }
 
-    public async listDocuments(applicationId: string): Promise<UnitResponse<ApplicationDocument[]> | UnitError> {
+    public async listDocuments(applicationId: string): Promise<UnitResponse<ApplicationDocument[]>> {
         return this.httpGet<UnitResponse<ApplicationDocument[]>>(`/${applicationId}/documents`)
     }
 }

--- a/resources/applicationForm.ts
+++ b/resources/applicationForm.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from "./baseResource"
-import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitResponse } from "../types/common"
 import { CreateApplicationFormRequest, CreateApplicationFormResponse } from "../types/applicationForm"
 
 export class ApplicationForms extends BaseResource {
@@ -7,7 +7,7 @@ export class ApplicationForms extends BaseResource {
         super(token, basePath + "/application-forms", config)
     }
 
-    public async create(request: CreateApplicationFormRequest) : Promise<UnitResponse<CreateApplicationFormResponse> | UnitError> {
+    public async create(request: CreateApplicationFormRequest) : Promise<UnitResponse<CreateApplicationFormResponse>> {
         return this.httpPost<UnitResponse<CreateApplicationFormResponse>>("",{data: request})
     }
 }

--- a/resources/authorization.ts
+++ b/resources/authorization.ts
@@ -1,5 +1,5 @@
 import { Authorization } from "../types/authorization"
-import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitResponse } from "../types/common"
 import { BaseResource } from "./baseResource"
 
 export class Authorizations extends BaseResource {
@@ -8,11 +8,11 @@ export class Authorizations extends BaseResource {
         super(token, basePath + "/authorizations", config)
     }
 
-    public async get(id: string): Promise<UnitResponse<Authorization> | UnitError> {
+    public async get(id: string): Promise<UnitResponse<Authorization>> {
         return this.httpGet<UnitResponse<Authorization>>(`/${id}`)
     }
 
-    public async find(params?: AuthorizationQueryParams): Promise<UnitResponse<Authorization[]> | UnitError> {
+    public async find(params?: AuthorizationQueryParams): Promise<UnitResponse<Authorization[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),

--- a/resources/authorizationRequest.ts
+++ b/resources/authorizationRequest.ts
@@ -3,7 +3,7 @@ import {
     DeclineAuthorizationRequest,
     PurchaseAuthorizationRequest
 } from "../types/authorizationRequest"
-import { UnitResponse, UnitError, UnitConfig } from "../types/common"
+import { UnitResponse, UnitConfig } from "../types/common"
 import { BaseResource } from "./baseResource"
 
 
@@ -13,11 +13,11 @@ export class AuthorizationRequests extends BaseResource {
         super(token, basePath + "/authorization-requests", config)
     }
 
-    public async get(id: string): Promise<UnitResponse<PurchaseAuthorizationRequest> | UnitError> {
+    public async get(id: string): Promise<UnitResponse<PurchaseAuthorizationRequest>> {
         return this.httpGet<UnitResponse<PurchaseAuthorizationRequest>>(`/${id}`)
     }
 
-    public async list(params?: AuthorizationRequestQueryParams): Promise<UnitResponse<PurchaseAuthorizationRequest[]> | UnitError> {
+    public async list(params?: AuthorizationRequestQueryParams): Promise<UnitResponse<PurchaseAuthorizationRequest[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -28,7 +28,7 @@ export class AuthorizationRequests extends BaseResource {
         return this.httpGet<UnitResponse<PurchaseAuthorizationRequest[]>>("", { params: parameters })
     }
 
-    public async approve(request: ApproveAuthorizationRequest): Promise<UnitResponse<PurchaseAuthorizationRequest> | UnitError> {
+    public async approve(request: ApproveAuthorizationRequest): Promise<UnitResponse<PurchaseAuthorizationRequest>> {
         const path = `/${request.id}/approve`
         const data = {
             type: "approveAuthorizationRequest",
@@ -39,7 +39,7 @@ export class AuthorizationRequests extends BaseResource {
         return await this.httpPost<UnitResponse<PurchaseAuthorizationRequest>>(path, { data })
     }
 
-    public async decline(request: DeclineAuthorizationRequest): Promise<UnitResponse<PurchaseAuthorizationRequest> | UnitError> {
+    public async decline(request: DeclineAuthorizationRequest): Promise<UnitResponse<PurchaseAuthorizationRequest>> {
         const path = `/${request.id}/decline`
         const data = {
             type: "declineAuthorizationRequest",

--- a/resources/baseResource.ts
+++ b/resources/baseResource.ts
@@ -18,55 +18,56 @@ export class BaseResource {
         this.axios = config?.axios ?? axiosStatic
     }
 
-    protected async httpGet<T>(path: string, config?: { headers?: object; params?: object; }) : Promise<UnitError | T> {
+    protected async httpGet<T>(path: string, config?: { headers?: object; params?: object; }) : Promise<T> {
 
         const conf = {
             headers: this.mergeHeaders(config?.headers),
             ...(config?.params && { params: (config.params)})
         }
 
-        return await this.axios.get<T | UnitError>(this.resourcePath + path, conf)
+        return await this.axios.get<T>(this.resourcePath + path, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw extractUnitError(error) })
+            .catch(error => { throw extractUnitError(error) })
     }
 
-    protected async httpPatch<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T> {
+    protected async httpPatch<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<T> {
         const conf = {
             headers: this.mergeHeaders(config?.headers),
             ...(config?.params && { params: (config.params) })
         }
 
-        return await this.axios.patch<T | UnitError>(this.resourcePath + path, data, conf)
+        return await this.axios.patch<T>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw extractUnitError(error) })
+            .catch(error => { throw extractUnitError(error) })
     }
 
-    protected async httpPost<T>(path: string, data?: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T>{
+    protected async httpPost<T>(path: string, data?: object, config?: { headers?: object; params?: object; }) : Promise<T>{
         const conf = {
             headers: this.mergeHeaders(config?.headers),
             ...(config?.params && { params: (config.params) })
         }
 
-        return await this.axios.post<T | UnitError>(this.resourcePath + path, data, conf)
+        return await this.axios.post<T>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw extractUnitError(error) })
+            .catch(error => { throw extractUnitError(error) })
     }
 
-    protected async httpPut<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<UnitError | T>{
+    protected async httpPut<T>(path: string, data: object, config?: { headers?: object; params?: object; }) : Promise<T>{
         const conf = {
             headers: this.mergeHeaders(config?.headers),
             ...(config?.params && { params: (config.params) })
         }
 
-        return await this.axios.put<T | UnitError>(this.resourcePath + path, data, conf)
+        return await this.axios.put<T>(this.resourcePath + path, data, conf)
             .then(r => r.data)
-            .catch<UnitError>(error => { throw extractUnitError(error) })
+            .catch(error => { throw extractUnitError(error) })
     }
 
-    protected async httpDelete<T>(path: string) : Promise<UnitError | T> {
-        return await this.axios.delete<T | UnitError>(this.resourcePath + path, {headers: this.headers})
+
+    protected async httpDelete<T>(path: string) : Promise<T> {
+        return await this.axios.delete<T>(this.resourcePath + path, {headers: this.headers})
             .then(r => r.data)
-            .catch<UnitError>(error => { throw extractUnitError(error) })
+            .catch(error => { throw extractUnitError(error) })
     }
 
     private mergeHeaders(configHeaders: object | undefined){

--- a/resources/batchAccounts.ts
+++ b/resources/batchAccounts.ts
@@ -1,5 +1,5 @@
 import { BatchRelease } from "../types/batchAccount"
-import { Address, Relationship, UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { Address, Relationship, UnitConfig, UnitResponse } from "../types/common"
 import { BaseResource } from "./baseResource"
 
 export class BatchAccounts extends BaseResource {
@@ -7,7 +7,7 @@ export class BatchAccounts extends BaseResource {
         super(token, basePath + "/batch-releases", config)
     }
 
-    public async create(request: CraeteBatchReleaseRequest): Promise<UnitResponse<BatchRelease> | UnitError> {
+    public async create(request: CraeteBatchReleaseRequest): Promise<UnitResponse<BatchRelease>> {
         return this.httpPost<UnitResponse<BatchRelease>>("", { data: request })
     }
 }

--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -1,5 +1,5 @@
 import { Card, CreateDebitCardRequest, ReplaceCardRequest } from "../types/cards"
-import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { Include, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
 import { BaseResource } from "./baseResource"
@@ -10,36 +10,36 @@ export class Cards extends BaseResource {
         super(token, basePath + "/cards", config)
     }
 
-    public async createDebitCard(request: CreateDebitCardRequest): Promise<UnitResponse<Card> | UnitError> {
+    public async createDebitCard(request: CreateDebitCardRequest): Promise<UnitResponse<Card>> {
         return await this.httpPost<UnitResponse<Card>>("", { data: request })
     }
 
-    public async reportStolen(id: number): Promise<UnitResponse<Card> | UnitError> {
+    public async reportStolen(id: number): Promise<UnitResponse<Card>> {
         const path = `/${id}/report-stolen`
         return await this.httpPost<UnitResponse<Card>>(path)
     }
 
-    public async reportLost(id: string): Promise<UnitResponse<Card> | UnitError> {
+    public async reportLost(id: string): Promise<UnitResponse<Card>> {
         const path = `/${id}/report-lost`
         return await this.httpPost<UnitResponse<Card>>(path)
     }
 
-    public async closeCard(id: string): Promise<UnitResponse<Card> | UnitError> {
+    public async closeCard(id: string): Promise<UnitResponse<Card>> {
         const path = `/${id}/close`
         return await this.httpPost<UnitResponse<Card>>(path)
     }
 
-    public async freeze(id: string): Promise<UnitResponse<Card> | UnitError> {
+    public async freeze(id: string): Promise<UnitResponse<Card>> {
         const path = `/${id}/freeze`
         return await this.httpPost<UnitResponse<Card>>(path)
     }
 
-    public async unfreeze(id: string): Promise<UnitResponse<Card> | UnitError> {
+    public async unfreeze(id: string): Promise<UnitResponse<Card>> {
         const path = `/${id}/unfreeze`
         return await this.httpPost<UnitResponse<Card>>(path)
     }
 
-    public async replace(request: ReplaceCardRequest): Promise<UnitResponse<Card> | UnitError> {
+    public async replace(request: ReplaceCardRequest): Promise<UnitResponse<Card>> {
         const path = `/${request.id}/replace`
         const data = {
             type: "replaceCard",
@@ -56,13 +56,13 @@ export class Cards extends BaseResource {
      * @param include - Optional. A comma-separated list of related resources to include in the response.
      * Related resources include: customer, account. See [Getting Related Resources](https://developers.unit.co/#intro-getting-related-resources).
      */
-    public async get(id: string, include = ""): Promise<UnitResponse<Card> | UnitError> {
+    public async get(id: string, include = ""): Promise<UnitResponse<Card>> {
         const path = `/${id}?include=${include}`
 
         return await this.httpGet<UnitResponse<Card> & Include<Account[] | Customer[]>>(path)
     }
 
-    public async list(params?: CardListParams): Promise<UnitResponse<Card> & Include<Account[] | Customer[]> | UnitError> {
+    public async list(params?: CardListParams): Promise<UnitResponse<Card> & Include<Account[] | Customer[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),

--- a/resources/counterparty.ts
+++ b/resources/counterparty.ts
@@ -1,4 +1,4 @@
-import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitResponse } from "../types/common"
 import { AchCounterparty, CreateCounterpartyRequest, PatchCounterpartyRequest } from "../types/counterparty"
 import { BaseResource } from "./baseResource"
 
@@ -8,19 +8,19 @@ export class Counterparties extends BaseResource {
         super(token, basePath + "/counterparties", config)
     }
 
-    public async create(request: CreateCounterpartyRequest): Promise<UnitResponse<AchCounterparty> | UnitError> {
+    public async create(request: CreateCounterpartyRequest): Promise<UnitResponse<AchCounterparty>> {
         return await this.httpPost<UnitResponse<AchCounterparty>>("", { data: request })
     }
 
-    public async delete(id: string): Promise<UnitResponse<AchCounterparty> | UnitError> {
+    public async delete(id: string): Promise<UnitResponse<AchCounterparty>> {
         return await this.httpDelete<UnitResponse<AchCounterparty>>(`/${id}`)
     }
 
-    public async get(id: string): Promise<UnitResponse<AchCounterparty> | UnitError> {
+    public async get(id: string): Promise<UnitResponse<AchCounterparty>> {
         return await this.httpGet<UnitResponse<AchCounterparty>>(`/${id}`)
     }
 
-    public async list(params?: CounterpartyListParams): Promise<UnitResponse<AchCounterparty[]> | UnitError> {
+    public async list(params?: CounterpartyListParams): Promise<UnitResponse<AchCounterparty[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -30,8 +30,8 @@ export class Counterparties extends BaseResource {
         return this.httpGet<UnitResponse<AchCounterparty[]>>("", { params: parameters })
     }
 
-    public async update(id: string, request: PatchCounterpartyRequest): Promise<UnitResponse<AchCounterparty> | UnitError> {
-        return this.httpPatch<Promise<UnitResponse<AchCounterparty> | UnitError>>(`/${id}`, { data: request })
+    public async update(id: string, request: PatchCounterpartyRequest): Promise<UnitResponse<AchCounterparty>> {
+        return this.httpPatch<Promise<UnitResponse<AchCounterparty>>>(`/${id}`, { data: request })
     }
 }
 

--- a/resources/customer.ts
+++ b/resources/customer.ts
@@ -1,4 +1,4 @@
-import { UnitResponse, UnitError, UnitConfig } from "../types/common"
+import { UnitResponse, UnitConfig } from "../types/common"
 import { Customer, PatchCustomerRequest } from "../types/customer"
 import { BaseResource } from "./baseResource"
 
@@ -8,15 +8,15 @@ export class Customers extends BaseResource {
         super(token, basePath + "/customers", config)
     }
 
-    public async update(request: PatchCustomerRequest): Promise<UnitResponse<Customer> | UnitError>{
+    public async update(request: PatchCustomerRequest): Promise<UnitResponse<Customer>>{
         return this.httpPatch<UnitResponse<Customer>>(`/${request.customerId}`, { data: request.data })
     }
 
-    public async get(customerId: string): Promise<UnitResponse<Customer> | UnitError> {
+    public async get(customerId: string): Promise<UnitResponse<Customer>> {
         return this.httpGet<UnitResponse<Customer>>(`/${customerId}`)
     }
 
-    public async list(params?: CustomersListParams): Promise<UnitResponse<Customer[]> | UnitError> {
+    public async list(params?: CustomersListParams): Promise<UnitResponse<Customer[]>> {
 
         const parameters = {
             "page[limit]": (params?.limit ? params.limit : 100),

--- a/resources/customerToken.ts
+++ b/resources/customerToken.ts
@@ -1,4 +1,4 @@
-import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitResponse } from "../types/common"
 import {
     CreateTokenRequest,
     CreateTokenVerificationRequest,
@@ -12,11 +12,11 @@ export class CustomerTokens extends BaseResource {
         super(token,basePath + "/customers", config)
     }
 
-    public async createToken(customerId: string, request: CreateTokenRequest) : Promise<UnitResponse<CustomerToken> | UnitError> {
+    public async createToken(customerId: string, request: CreateTokenRequest) : Promise<UnitResponse<CustomerToken>> {
         return this.httpPost<UnitResponse<CustomerToken>>(`/${customerId}/token`, { data: request })
     }
 
-    public async createTokenVerification(customerId: string, request: CreateTokenVerificationRequest) : Promise<UnitResponse<VerificationToken> | UnitError> {
+    public async createTokenVerification(customerId: string, request: CreateTokenVerificationRequest) : Promise<UnitResponse<VerificationToken>> {
         return this.httpPost<UnitResponse<VerificationToken>>(`/${customerId}/token/verification`,{ data: request})
     }
 }

--- a/resources/events.ts
+++ b/resources/events.ts
@@ -1,4 +1,4 @@
-import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitResponse } from "../types/common"
 import { UnitEvent } from "../types/events"
 import { BaseResource } from "./baseResource"
 
@@ -8,11 +8,11 @@ export class Events extends BaseResource {
         super(token, basePath + "/events", config)
     }
 
-    public async get(id: string): Promise<UnitResponse<UnitEvent> | UnitError> {
+    public async get(id: string): Promise<UnitResponse<UnitEvent>> {
         return await this.httpGet<UnitResponse<UnitEvent>>(`/${id}`)
     }
 
-    public async list(params?: EventListParams): Promise<UnitResponse<UnitEvent[]> | UnitError> {
+    public async list(params?: EventListParams): Promise<UnitResponse<UnitEvent[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0)
@@ -21,7 +21,7 @@ export class Events extends BaseResource {
         return this.httpGet<UnitResponse<UnitEvent[]>>("", { params: parameters })
     }
 
-    public async fire(id: string): Promise<UnitResponse<UnitEvent> | UnitError> {
+    public async fire(id: string): Promise<UnitResponse<UnitEvent>> {
         return await this.httpPost<UnitResponse<UnitEvent>>(`/${id}`)
     }
 }

--- a/resources/fee.ts
+++ b/resources/fee.ts
@@ -1,4 +1,4 @@
-import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitResponse } from "../types/common"
 import { CreateFeeRequest, Fee } from "../types/fee"
 import { BaseResource } from "./baseResource"
 
@@ -7,7 +7,7 @@ export class Fees extends BaseResource {
         super(token, basePath + "/fees", config)
     }
 
-    public async createFee(request: CreateFeeRequest): Promise<UnitResponse<Fee> | UnitError> {
+    public async createFee(request: CreateFeeRequest): Promise<UnitResponse<Fee>> {
         return this.httpPost<UnitResponse<Fee>>("", { data: request })
     }
 }

--- a/resources/payments.ts
+++ b/resources/payments.ts
@@ -1,5 +1,5 @@
 import { Account } from "../types/account"
-import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { Include, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { AchPayment, CreatePaymentRequest, PatchPaymentRequest, Payment } from "../types/payments"
 import { Transaction } from "../types/transactions"
@@ -10,11 +10,11 @@ export class Payments extends BaseResource {
         super(token, basePath + "/payments", config)
     }
 
-    public async create(request: CreatePaymentRequest) : Promise<UnitResponse<AchPayment> | UnitError> {
+    public async create(request: CreatePaymentRequest) : Promise<UnitResponse<AchPayment>> {
         return this.httpPost<UnitResponse<AchPayment>>("",{data: request})
     }
 
-    public async update(id: string, request: PatchPaymentRequest) : Promise<UnitResponse<Payment> | UnitError> {
+    public async update(id: string, request: PatchPaymentRequest) : Promise<UnitResponse<Payment>> {
         return this.httpPatch<UnitResponse<Payment>>(`/${id}`, {data: request})
     }
 
@@ -22,12 +22,12 @@ export class Payments extends BaseResource {
      * Optional. A comma-separated list of related resources to include in the response.
      * Related resources include: customer, account, transaction. See Getting Related Resources
      */
-    public async get(id: string, include?: string) : Promise<UnitResponse<AchPayment & Include<Account[] | Customer[] | Transaction[]>> | UnitError> {
+    public async get(id: string, include?: string) : Promise<UnitResponse<AchPayment & Include<Account[] | Customer[] | Transaction[]>>> {
         const params = {include : include ? `include=${include}` : ""}
         return this.httpGet<UnitResponse<AchPayment & Include<Account[] | Customer[] | Transaction[]>>>(`/${id}`,{params})
     }
 
-    public async list(params?: PaymentListParams) : Promise<UnitResponse<AchPayment[] & Include<Account[] | Customer[] | Transaction[]>> | UnitError> {
+    public async list(params?: PaymentListParams) : Promise<UnitResponse<AchPayment[] & Include<Account[] | Customer[] | Transaction[]>>> {
         const parameters = {
             "page[limit]": (params?.limit ? params.limit : 100),
             "page[offset]": (params?.offset ? params.offset : 0),

--- a/resources/returns.ts
+++ b/resources/returns.ts
@@ -1,4 +1,4 @@
-import { UnitResponse, UnitError, UnitConfig } from "../types/common"
+import { UnitResponse, UnitConfig } from "../types/common"
 import { ReturnReceivedAchTransactionRequest } from "../types/returns"
 import { ReturnedReceivedAchTransaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
@@ -8,7 +8,7 @@ export class Returns extends BaseResource {
         super(token, basePath + "/returns", config)
     }
 
-    public async return(request: ReturnReceivedAchTransactionRequest): Promise<UnitResponse<ReturnedReceivedAchTransaction> | UnitError> {
+    public async return(request: ReturnReceivedAchTransactionRequest): Promise<UnitResponse<ReturnedReceivedAchTransaction>> {
         return this.httpPost<UnitResponse<ReturnedReceivedAchTransaction>>(`/${request.transactionId}`, { data: request.data })
     }
 }

--- a/resources/statements.ts
+++ b/resources/statements.ts
@@ -1,4 +1,4 @@
-import { Statement, UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { Statement, UnitConfig, UnitResponse } from "../types/common"
 import { BaseResource } from "./baseResource"
 
 export class Statments extends BaseResource {
@@ -6,7 +6,7 @@ export class Statments extends BaseResource {
         super(token, basePath + "/statements", config)
     }
 
-    public async list(params?: StatementsListParams): Promise<UnitResponse<Statement[]> | UnitError> {
+    public async list(params?: StatementsListParams): Promise<UnitResponse<Statement[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -17,7 +17,7 @@ export class Statments extends BaseResource {
         return this.httpGet<UnitResponse<Statement[]>>("", { params: parameters })
     }
 
-    public get(statementId: string, customerId?: string): Promise<UnitResponse<Statement> | UnitError> {
+    public get(statementId: string, customerId?: string): Promise<UnitResponse<Statement>> {
         const parameters = {
             ...(customerId && { "filter[customerId]": customerId })
         }

--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -1,4 +1,4 @@
-import { Include, UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { Include, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
 import { Transaction } from "../types/transactions"
@@ -19,7 +19,7 @@ export class Transactions extends BaseResource {
      * Related resources include: customer, account. [See Getting Related Resources](https://developers.unit.co/#intro-getting-related-resources)
      * @returns
      */
-    public async get(accountId: string, transactionId: string, customerId?: string, include?: string): Promise<UnitResponse<Transaction> & Include<Account[] | Customer[]> | UnitError> {
+    public async get(accountId: string, transactionId: string, customerId?: string, include?: string): Promise<UnitResponse<Transaction> & Include<Account[] | Customer[]>> {
         const parameters = {
             ...(customerId && { "filter[customerId]": customerId }),
             "include": include ? include : ""
@@ -28,7 +28,7 @@ export class Transactions extends BaseResource {
         return await this.httpGet<UnitResponse<Transaction> & Include<Account[] | Customer[]>>(`/accounts/${accountId}/transactions/${transactionId}`, { params: parameters })
     }
 
-    public async list(params?: TransactionListParams): Promise<UnitResponse<Transaction[]> & Include<Account[] | Customer[]> | UnitError> {
+    public async list(params?: TransactionListParams): Promise<UnitResponse<Transaction[]> & Include<Account[] | Customer[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params.limit : 100),
             "page[offset]": (params?.offset ? params.offset : 0),
@@ -53,7 +53,7 @@ export class Transactions extends BaseResource {
      * @param tags - See [Updating Tags](https://developers.unit.co/#tags).
      * @returns
      */
-    public async update(accountId: string, transactionId: string, tags: object): Promise<UnitResponse<Transaction> | UnitError> {
+    public async update(accountId: string, transactionId: string, tags: object): Promise<UnitResponse<Transaction>> {
         const data = {
             type: "transaction",
             attributes: {

--- a/resources/webhooks.ts
+++ b/resources/webhooks.ts
@@ -1,4 +1,4 @@
-import { UnitConfig, UnitError, UnitResponse } from "../types/common"
+import { UnitConfig, UnitResponse } from "../types/common"
 import { CreateWebhookRequest, PatchWebhookRequest, Webhook } from "../types/webhooks"
 import { BaseResource } from "./baseResource"
 
@@ -7,33 +7,33 @@ export class Webhooks extends BaseResource {
         super(token, basePath + "/webhooks", config)
     }
 
-    public async create(request: CreateWebhookRequest): Promise<UnitResponse<Webhook> | UnitError> {
-        return this.httpPost<UnitResponse<Webhook> | UnitError>("", { data: request })
+    public async create(request: CreateWebhookRequest): Promise<UnitResponse<Webhook>> {
+        return this.httpPost<UnitResponse<Webhook>>("", { data: request })
     }
 
-    public async get(id: string): Promise<UnitResponse<Webhook> | UnitError> {
-        return this.httpGet<UnitResponse<Webhook> | UnitError>(`/${id}`)
+    public async get(id: string): Promise<UnitResponse<Webhook>> {
+        return this.httpGet<UnitResponse<Webhook>>(`/${id}`)
     }
 
-    public async list(params?: WebhookListParams): Promise<UnitResponse<Webhook[]> | UnitError> {
+    public async list(params?: WebhookListParams): Promise<UnitResponse<Webhook[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params.limit : 100),
             "page[offset]": (params?.offset ? params.offset : 0)
         }
 
-        return this.httpGet<UnitResponse<Webhook[]> | UnitError>("", { params: parameters })
+        return this.httpGet<UnitResponse<Webhook[]>>("", { params: parameters })
     }
 
-    public async update(id: string, request: PatchWebhookRequest): Promise<UnitResponse<Webhook> | UnitError> {
-        return this.httpPatch<UnitResponse<Webhook> | UnitError>(`/${id}`, { data: request })
+    public async update(id: string, request: PatchWebhookRequest): Promise<UnitResponse<Webhook>> {
+        return this.httpPatch<UnitResponse<Webhook>>(`/${id}`, { data: request })
     }
 
-    public async enable(id: string): Promise<UnitResponse<Webhook> | UnitError> {
-        return this.httpPost<UnitResponse<Webhook> | UnitError>(`/${id}/enable`)
+    public async enable(id: string): Promise<UnitResponse<Webhook>> {
+        return this.httpPost<UnitResponse<Webhook>>(`/${id}/enable`)
     }
 
-    public async disable(id: string): Promise<UnitResponse<Webhook> | UnitError> {
-        return this.httpPost<UnitResponse<Webhook> | UnitError>(`/${id}/disable`)
+    public async disable(id: string): Promise<UnitResponse<Webhook>> {
+        return this.httpPost<UnitResponse<Webhook>>(`/${id}/disable`)
     }
 }
 

--- a/unit.ts
+++ b/unit.ts
@@ -62,8 +62,10 @@ export class Unit {
         this.helpers = helpers
     }
 
+
     isError<T>(response: T | UnitError): response is UnitError {
-        return (response as UnitError).isUnitError
+        // noinspection PointlessBooleanExpressionJS
+        return (response as UnitError).isUnitError === true
     }
 }
 


### PR DESCRIPTION
Currently, all resource functions are annotated with the return type `Promise<UnitError | T>`, but these functions never resolve the promise with an object of type `UnitError`, only with objects of type `T`. 

This PR removes `UnitError` from the return type annotation of resource functions. This was done since it's ergonomically frustrating to consume these functions in typescript, where after every invocation, I have to do a pointless assertion that the response is `!isUnitError` to appease the compiler that the response is indeed of type `T`. 

I suspect this is an artifact from a time when this implementation returned the UnitError instead of throwing it. 

There are two options to resolve this concern: 
1. (**proposed**) Keep the exception-based control flow for handling non-2xx responses from the API server and remove `UnitError` from the return type annotation from resource functions. _This is the generally favoured strategy in most modern commercial API clients_

2. Revert to returning the `UnitError` and force users to call `isUnitError` before consuming response. _This is not the most ergonomic, since it forces the user to explicitly check for errors after every call_
