### PR TITLE
Convert application and customer DTOs into unions of sibling interfaces

### DIFF
--- a/types/application.ts
+++ b/types/application.ts
@@ -7,7 +7,9 @@ export type ApplicationStatus =
     "Approved" |          //The application was approved. A Customer resource was created.
     "Denied"              //The application was denied. A Customer resource will not be created.
 
-export interface Application {
+export type Application = IndividualApplication | BusinessApplication
+
+export interface BaseApplication {
     /**
      * Identifier of the application resource.
      */
@@ -40,7 +42,7 @@ export interface Application {
     }
 }
 
-export interface IndividualApplication extends Application {
+export interface IndividualApplication extends BaseApplication {
     type: "individualApplication"
 
     attributes: {
@@ -129,7 +131,7 @@ export interface IndividualApplication extends Application {
     }
 }
 
-export interface BusinessApplication extends Application {
+export interface BusinessApplication extends BaseApplication {
     type: "businessApplication"
 
     attributes: {
@@ -320,7 +322,7 @@ export interface CreateIndividualApplicationRequest {
 
         /**
          * Required on passport only. Two letters representing the individual nationality.
-         * ISO31661-Alpha2 
+         * ISO31661-Alpha2
          */
         nationality?: string
 

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -1,7 +1,8 @@
 import { Address, AuthorizedUser, BusinessContact, FullName, Phone, Relationship, State } from "./common"
 
+export type Customer = IndividualCustomer | BusinessCustomer
 
-export interface Customer {
+export interface BaseCustomer {
     /**
      * Identifier of the individual resource.
      */
@@ -28,7 +29,7 @@ export interface Customer {
     }
 }
 
-export interface IndividualCustomer extends Customer {
+export interface IndividualCustomer extends BaseCustomer {
     /**
      * Type of the resource, the value is always individualCustomer.
      */
@@ -93,7 +94,7 @@ export interface IndividualCustomer extends Customer {
     }
 }
 
-export interface BusinessCustomer extends Customer {
+export interface BusinessCustomer extends BaseCustomer {
     /**
      * Type of the resource, the value is always businessCustomer.
      */
@@ -152,7 +153,7 @@ export interface BusinessCustomer extends Customer {
         /**
          * Array of authorized users.
          * An authorized user is someone who can participate in the One Time Password(OTP) authentication process.
-         * 
+         *
          */
         authorizedUsers: AuthorizedUser[]
 
@@ -221,7 +222,7 @@ export interface PatchBusinessCustomerRequest {
             phone?: Phone
 
             /**
-             * Primary contact of the business.	
+             * Primary contact of the business.
              */
             contact?: BusinessContact
 


### PR DESCRIPTION
The unit API makes use of union types in its responses. The client currently handles exposing these types incositently:  

- Certain types make use of the [union types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) typescript feature, e.g. [Accounts](https://github.com/unit-finance/unit-node-sdk/blob/main/types/account.ts), [Payments](https://github.com/unit-finance/unit-node-sdk/blob/main/types/payments.ts), [Transactions](https://github.com/unit-finance/unit-node-sdk/blob/main/types/transactions.ts):
   * [Accounts](https://github.com/unit-finance/unit-node-sdk/blob/main/types/account.ts): `export type Account = DepositAccount | BatchAccount`
   * [Payments](https://github.com/unit-finance/unit-node-sdk/blob/main/types/payments.ts): `export type Payment = AchPayment | BookPayment`

- Other types use inheritance to organize common properties into a base class which serves as the root class in the API interfaces, e.g. [Application](https://github.com/unit-finance/unit-node-sdk/blob/main/types/application.ts), [Customer](https://github.com/unit-finance/unit-node-sdk/blob/main/types/customer.ts)

This PR proposed the use of the the [union types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) typescript feature to consistently expose root types in the API interface. 