### PR TITLE
Fixed return types on list Cards and list Accounts

### DIFF
--- a/resources/account.ts
+++ b/resources/account.ts
@@ -30,7 +30,7 @@ export class Accounts extends BaseResource {
         return this.httpGet<UnitResponse<Account> & Include<Customer>>(`/${id}`, { params: { include } })
     }
 
-    public async list(params?: AccountListParams): Promise<UnitResponse<Account> & Include<Customer>> {
+    public async list(params?: AccountListParams): Promise<UnitResponse<Account[]> & Include<Customer[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -39,7 +39,7 @@ export class Accounts extends BaseResource {
             ...(params?.include && { "include": params?.include }),
         }
 
-        return this.httpGet<UnitResponse<Account> & Include<Customer>>("", { params: parameters })
+        return this.httpGet<UnitResponse<Account[]> & Include<Customer[]>>("", { params: parameters })
     }
 
     public async update(request: PatchAccountRequest) : Promise<UnitResponse<Account>> {

--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -62,7 +62,7 @@ export class Cards extends BaseResource {
         return await this.httpGet<UnitResponse<Card> & Include<Account[] | Customer[]>>(path)
     }
 
-    public async list(params?: CardListParams): Promise<UnitResponse<Card> & Include<Account[] | Customer[]>> {
+    public async list(params?: CardListParams): Promise<UnitResponse<Cards> & Include<Account[] | Customer[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -71,7 +71,7 @@ export class Cards extends BaseResource {
             ...(params?.include && { "include": params?.include })
         }
 
-        return this.httpGet<UnitResponse<Card> & Include<Account[] | Customer[]>>("", { params: parameters })
+        return this.httpGet<UnitResponse<Cards> & Include<Account[] | Customer[]>>("", { params: parameters })
     }
 }
 

--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -62,7 +62,7 @@ export class Cards extends BaseResource {
         return await this.httpGet<UnitResponse<Card> & Include<Account[] | Customer[]>>(path)
     }
 
-    public async list(params?: CardListParams): Promise<UnitResponse<Cards> & Include<Account[] | Customer[]>> {
+    public async list(params?: CardListParams): Promise<UnitResponse<Card[]> & Include<Account[] | Customer[]>> {
         const parameters = {
             "page[limit]": (params?.limit ? params?.limit : 100),
             "page[offset]": (params?.offset ? params?.offset : 0),
@@ -71,7 +71,7 @@ export class Cards extends BaseResource {
             ...(params?.include && { "include": params?.include })
         }
 
-        return this.httpGet<UnitResponse<Cards> & Include<Account[] | Customer[]>>("", { params: parameters })
+        return this.httpGet<UnitResponse<Card[]> & Include<Account[] | Customer[]>>("", { params: parameters })
     }
 }
 

--- a/types/cards.ts
+++ b/types/cards.ts
@@ -1,7 +1,6 @@
 import { Address, FullName, Phone, Relationship } from "./common"
 
 export type Card = IndividualDebitCard | BusinessDebitCard | IndividualVirtualDebitCard | BusinessVirtualDebitCard
-export type Cards = Card[]
 
 export type cardStatus = "Active" | "Inactive" | "Stolen" | "Lost" | "Frozen" | "ClosedByCustomer" | "SuspectedFraud"
 
@@ -116,7 +115,7 @@ export interface BusinessDebitCard {
 
         /**
          * Only when Passport is populated. Two letters representing the card holder nationality. (e.g. “US”).
-         * ISO31661 - Alpha2 format. For more information: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2	
+         * ISO31661 - Alpha2 format. For more information: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
          */
         nationality?: string
 
@@ -375,7 +374,7 @@ export interface CreateBusinessDebitCardRequest {
 
         /**
          * Required on passport only. Two letters representing the card holder nationality. (e.g. “US”).
-         * ISO31661 - Alpha2 format. For more information: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2	
+         * ISO31661 - Alpha2 format. For more information: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
          */
         nationality?: string
 
@@ -467,7 +466,7 @@ export interface CreateBusinessVirtualDebitCardRequest {
 
         /**
          * Required on passport only. Two letters representing the card holder nationality. (e.g. “US”).
-         * ISO31661 - Alpha2 format. For more information: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2	
+         * ISO31661 - Alpha2 format. For more information: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
          */
         nationality?: string
 

--- a/types/cards.ts
+++ b/types/cards.ts
@@ -1,6 +1,7 @@
 import { Address, FullName, Phone, Relationship } from "./common"
 
 export type Card = IndividualDebitCard | BusinessDebitCard | IndividualVirtualDebitCard | BusinessVirtualDebitCard
+export type Cards = Card[]
 
 export type cardStatus = "Active" | "Inactive" | "Stolen" | "Lost" | "Frozen" | "ClosedByCustomer" | "SuspectedFraud"
 


### PR DESCRIPTION
The return types on the Accounts#list and Cards#list operations were not array types. Which should be the expected return types for clients based on Unit's SDK. See: 
* https://docs.unit.co/#list-deposit-accounts
* https://docs.unit.co/#list-cards