### PR TITLE
Added missing field `expiresIn` to `customerTokenRequest`

### DIFF
--- a/types/customerToken.ts
+++ b/types/customerToken.ts
@@ -19,6 +19,11 @@ export interface CreateTokenRequest {
          * Required if the scope attribute includes a scope which requires two-factor authentication.
          */
         verificationCode?: string
+        /**
+         * Optional. The lifetime of the token (in seconds). 
+         * Maximum value is 86400 (24 hours). Default value is also 24 hours.
+         */
+        expiresIn: number
     }
 }
 


### PR DESCRIPTION
See: https://docs.unit.co/#customers-create-customer-bearer-token