### PR TITLE
add AccountEndOfDay class + types

### DIFF
--- a/resources/accountEndOfDay.ts
+++ b/resources/accountEndOfDay.ts
@@ -1,0 +1,63 @@
+import { Include, UnitResponse, UnitConfig } from "../types/common"
+import { Customer } from "../types/customer"
+import { Account } from "../types/account"
+import { BaseResource } from "./baseResource"
+import { AccountEndOfDay } from "../types/accountEndOfDay"
+
+export class AccountsEndOfDay extends BaseResource {
+
+    constructor(token: string, basePath: string, config?: UnitConfig) {
+        super(token, basePath + '/account-end-of-day', config)
+    }
+
+    public async list(params?: AccountEndOfDayParams): Promise<UnitResponse<AccountEndOfDay[]> & Include<Customer> & Include<Account> & Include<Customer[]>> {
+        const parameters = {
+            "page[limit]": (params?.limit ? params?.limit : 100),
+            "page[offset]": (params?.offset ? params?.offset : 0),
+            ...(params?.customerId && { "filter[customerId]": params?.customerId }),
+            ...(params?.accountId && { "filter[accountId]": params?.accountId }),
+            ...(params?.since && { "filter[since]": params?.since }),
+            ...(params?.until && { "filter[until]": params?.until }),
+        }
+
+        return this.httpGet<UnitResponse<AccountEndOfDay[]> & Include<Customer> & Include<Account> & Include<Customer[]>>("", { params: parameters })
+    }
+}
+
+export interface AccountEndOfDayParams {
+    /**
+     * Maximum number of resources that will be returned. Maximum is 1000 resources. [See Pagination](https://developers.unit.co/#intro-pagination).
+     * default: 100
+     */
+    limit?: number
+
+    /**
+     * Number of resources to skip.  [See Pagination](https://developers.unit.co/#intro-pagination).
+     * default: 0
+     */
+    offset?: number
+
+    /**
+     * Optional. Filters the results by the specified customer id.
+     * default: empty
+     */
+    customerId?: string
+
+    /**
+     * Optional. Filters the results by the specified account id.
+     * default: empty
+     */
+    accountId?: string
+
+    /**
+     * Optional. Filters the account end-of-day balances before the specified date. e.g. 2021-06-01
+     * default: empty
+     */
+    since?: string
+
+    /**
+     * Optional. Filters the account end-of-day balances after the specified date. e.g. 2021-07-01
+     * default: empty
+     */
+    until?: string
+}

--- a/types/accountEndOfDay.ts
+++ b/types/accountEndOfDay.ts
@@ -39,7 +39,7 @@ export interface AccountsEndOfDay {
     }
 
     /**
-     * Describes relationships between the deposit account resource and the customer.
+     * Describes relationships between the statement resource and other resources (account and customer).
      */
     relationships: {
         /**

--- a/types/accountEndOfDay.ts
+++ b/types/accountEndOfDay.ts
@@ -1,0 +1,60 @@
+import { Relationship } from "./common"
+
+export type AccountEndOfDay = AccountsEndOfDay
+
+export interface AccountsEndOfDay {
+    /**
+     * Identifier of the account end of day resource.
+     */
+    id: string
+
+    /**
+     * Type of the resource, the value is always accountEndOfDay.
+     */
+    type: "accountEndOfDay"
+
+    /**
+     * Representing the account end of day data.
+     */
+    attributes: {
+        /**
+         * The date the account end-of-day resource was created.
+         */
+        date: string
+
+        /**
+         * The balance amount (in cents).
+         */
+        balance: number
+
+        /**
+         * The hold amount (in cents).
+         */
+        hold: number
+
+        /**
+         * The available balance for spending (in cents).
+         */
+        available: number
+    }
+
+    /**
+     * Describes relationships between the deposit account resource and the customer.
+     */
+    relationships: {
+        /**
+         * The account.
+         */
+        account: Relationship
+   
+        /**
+         * The customer.
+         */
+        customer: Relationship
+   
+        /**
+         * The customers.
+         */
+        customers: Relationship[]
+    }
+}

--- a/unit.ts
+++ b/unit.ts
@@ -17,11 +17,13 @@ import { AuthorizationRequests } from "./resources/authorizationRequest"
 import { Statments } from "./resources/statements"
 import { Returns } from "./resources/returns"
 import { ApplicationForms } from "./resources/applicationForm"
+import { AccountsEndOfDay } from "./resources/accountEndOfDay"
 
 export class Unit {
     public applications: Applications
     public customers: Customers
     public accounts: Accounts
+    public accountsEndOfDay: AccountsEndOfDay
     public transactions: Transactions
     public cards: Cards
     public webhooks: Webhooks
@@ -45,6 +47,7 @@ export class Unit {
         this.applications = new Applications(token, basePath, config)
         this.customers = new Customers(token, basePath, config)
         this.accounts = new Accounts(token, basePath, config)
+        this.accountsEndOfDay = new AccountsEndOfDay(token, basePath, config)
         this.transactions = new Transactions(token, basePath, config)
         this.cards = new Cards(token, basePath, config)
         this.webhooks = new Webhooks(token, basePath, config)


### PR DESCRIPTION
Changes
- added `AccountsEndOfDay` class with the following method:
     - `list(params: AccountEndOfDayParams): Promise<UnitResponse<AccountEndOfDay[]> & Include<Customer> & Include<Account> & Include<Customer[]>>` 
- added `AccountsEndOfDay` interface with values and descriptions from unit docs: `https://docs.unit.co/resources#account-end-of-day`