### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ const unit = new Unit(UNIT_TOKEN, UNIT_API_URL)
         }
     }
 
-    let application = await unit.applications.create(createApplicationRequest).catch<UnitError>(err => {
+    const applicationOrError = await unit.applications.create(createApplicationRequest);
+    if ('data' in applicationOrError) {
+        console.log(application)
+    } else {
         // handle errors
-        return err
-    })
-
-    console.log(application)
+        return applicationOrError;
+    }
 })();
 ```
 


### PR DESCRIPTION
unit.applications.create returns `UnitResponse<T> | UnitError` so the error handling should happen by branching on the returned value, not with a try / catch, correct?