### PR TITLE
use union type for direction

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -177,7 +177,7 @@ interface TransactionCreated {
     attributes: {
         createdAt: string
         summary: string
-        direction: string
+        direction: "Credit" | "Debit"
         amount: string
     }
     relationships: {

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -24,7 +24,7 @@ interface BasePaymentAttributes {
     /**
      * The direction in which the funds flow (either Debit or Credit).
      */
-    direction: string
+    direction: "Credit" | "Debit"
 
     /**
      * Payment description (maximum of 10 characters), also known as Company Entry Description, this will show up on statement of the counterparty.
@@ -207,7 +207,7 @@ export interface CreateInlinePaymentRequest {
         /**
          * The direction in which the funds flow.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The party on the other side of the ACH payment.
@@ -261,7 +261,7 @@ export interface CreateLinkedPaymentRequest {
         /**
          * The direction in which the funds flow.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
         * Payment description (maximum of 10 characters), also known as Company Entry Description, this will show up on statement of the counterparty.
@@ -314,7 +314,7 @@ export interface CreateVerifiedPaymentRequest {
         /**
          * The direction in which the funds flow.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
         * Payment description (maximum of 10 characters), also known as Company Entry Description, this will show up on statement of the counterparty.

--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -28,7 +28,7 @@ export interface OriginatedAchTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -107,7 +107,7 @@ export interface ReceivedAchTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -201,7 +201,7 @@ export interface ReturnedAchTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -290,7 +290,7 @@ export interface ReturnedReceivedAchTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -369,7 +369,7 @@ export interface DishonoredAchTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -463,7 +463,7 @@ export interface BookTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -542,7 +542,7 @@ export interface PurchaseTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -655,7 +655,7 @@ export interface AtmTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -743,7 +743,7 @@ export interface FeeTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -811,7 +811,7 @@ export interface CardReversalTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -884,7 +884,7 @@ export interface CardTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -952,7 +952,7 @@ export interface WireTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -1122,7 +1122,7 @@ export interface AdjustmentTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The account balance (cents) after the transaction. Common to all transaction types.
@@ -1180,7 +1180,7 @@ export interface InterestTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.
@@ -1243,7 +1243,7 @@ export interface DisputeTransaction {
         /**
          * The direction in which the funds flow. Common to all transaction types.
          */
-        direction: string
+        direction: "Credit" | "Debit"
 
         /**
          * The amount (cents) of the transaction. Common to all transaction types.


### PR DESCRIPTION
It seems that `direction` is always either "Credit" or "Debit", correct?