### PR TITLE
add optional applicationForm to application type

### DIFF
--- a/types/application.ts
+++ b/types/application.ts
@@ -39,6 +39,11 @@ export interface BaseApplication {
          * Optional. The created Customer in case of approved application.
          */
         customer?: Relationship
+
+        /**
+         * Optional. The Application Form used to create the application.
+         */
+        applicationForm?: Relationship
     }
 }
 


### PR DESCRIPTION
## Context

On the Application resource, there exists an ApplicationForm relation that can be used to link end users that create an ApplicationForm with the resulting Application.  This is important for the CustomerCreated event which only has the Application resource as a relation.

This change aligns the Application type with the exposed Relationship with ApplicationForm

## Documentation links to the Application Relationships

https://docs.unit.co/resources#relationships
https://docs.unit.co/resources#relationships-1