### PR TITLE
Fix `CreateWebhookRequest`: optional `token`

### DIFF
--- a/types/webhooks.ts
+++ b/types/webhooks.ts
@@ -63,7 +63,7 @@ export interface CreateWebhookRequest {
         /**
          * The secret token(see Securing your webhooks).
          */
-        token: string
+        token?: string
 
         /**
          * The type of content you wish to receive. Always JsonAPI.


### PR DESCRIPTION
Fix the typings of `CreateWebhookRequest` - the `token` is optional in the API.