### PR TITLE
Update `BillPayment['attributes']`

### DIFF
--- a/types/payments.ts
+++ b/types/payments.ts
@@ -216,7 +216,7 @@ export interface BillPayment {
     /**
      * JSON object representing the payment resource.
      */
-    attributes: Pick<BasePaymentAttributes, "createdAt" | "status" | "direction" | "description" | "amount" | "tags">
+    attributes: Pick<BasePaymentAttributes, "createdAt" | "status" | "direction" | "description" | "amount" | "tags" | "reason">
 
     /**
      * Describes relationships between the Wire payment and the originating deposit account and customer.


### PR DESCRIPTION
Unsure why you `Pick` here when it's a `BasePaymentAttributes`, but here I add `reason` to returned attributes, as it's there sometimes.