### PR TITLE
add typing for account events

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -2,6 +2,9 @@ import {Relationship, Tags, UnimplementedFields, UnimplementedRelationships} fro
 
 export type UnitEvent =
     AccountClosed |
+    AccountFrozen |
+    AccountReopened |
+    AccountUnfrozen |
     ApplicationDenied |
     ApplicationAwaitingDocuments |
     ApplicationPendingReview |
@@ -35,6 +38,33 @@ export type AccountClosed = BaseEvent & {
     attributes: {
         closeReason: string
     }
+    relationships: {
+        account: Relationship
+        customer: Relationship
+    }
+}
+
+export type AccountFrozen = BaseEvent & {
+    type: "account.frozen"
+    attributes: {
+        freezeReason: string
+    }
+    relationships: {
+        account: Relationship
+        customer: Relationship
+    }
+}
+
+export type AccountReopened = BaseEvent & {
+    type: "account.reopened"
+    relationships: {
+        account: Relationship
+        customer: Relationship
+    }
+}
+
+export type AccountUnfrozen = BaseEvent & {
+    type: "account.unfrozen"
     relationships: {
         account: Relationship
         customer: Relationship


### PR DESCRIPTION
add missing typing for `account.reopened`, `account.frozen` and `account.unfrozen` as defined in the [api specification](https://docs.unit.co/events#accountreopened).