### PR TITLE
Support for card relationship in authorization

### DIFF
--- a/types/authorization.ts
+++ b/types/authorization.ts
@@ -70,5 +70,10 @@ export interface Authorization {
          * The customer the deposit account belongs to. The customer is either a business or a individual.
          */
         customer: Relationship
+        
+        /**
+         * The debit card involved in the authorization.
+         */
+        card: Relationship
     }
 }


### PR DESCRIPTION
`card` relationship not supported in the return type for authorization but is a response from the Unit api - https://docs.unit.co/resources#authorization