### PR TITLE
fix(types): make OriginatedAchTransaction.addenda optional

### DIFF
--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -100,7 +100,7 @@ export type OriginatedAchTransaction = BaseTransaction & {
         /**
          * Optional, additional transaction description.
          */
-        addenda: string
+        addenda?: string
 
         /**
          * The party on the other end of the transaction.


### PR DESCRIPTION
Both SDK documentation and API specification notes it as optional, see https://docs.unit.co/resources#transaction-originatedach