### PR TITLE
Make setting User-Agent optional

### DIFF
--- a/resources/baseResource.ts
+++ b/resources/baseResource.ts
@@ -12,7 +12,7 @@ export class BaseResource {
         this.headers = {
             "Authorization": `Bearer ${token}`,
             "Content-Type": "application/vnd.api+json",
-            "User-Agent": "unit-node-sdk"
+            ...(config?.sdkUserAgent && { "User-Agent": "unit-node-sdk" })
         }
 
         this.axios = config?.axios ?? axiosStatic

--- a/types/common.ts
+++ b/types/common.ts
@@ -522,6 +522,7 @@ export interface Meta extends UnimplementedFields {
 
 export interface UnitConfig {
     axios?: AxiosInstance
+    sdkUserAgent?: boolean
 }
 
 export class UnitError extends Error {


### PR DESCRIPTION
Allow the setting of the User-Agent header to be configurable. This allows us to use this SDK on the browser without having User-Agent errors pop up in console.