### PR TITLE
Build before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "jest .spec.ts --maxWorkers=1 --no-cache",
     "build": "tsc",
     "lint": "eslint **/*.ts",
-    "lint-fix": "eslint **/*.ts --fix"
+    "lint-fix": "eslint **/*.ts --fix",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is in case the one publishing the package
forgets to build