### PR TITLE
Improve types for received ACH payments resource

### DIFF
--- a/resources/receivedPayments.ts
+++ b/resources/receivedPayments.ts
@@ -1,7 +1,7 @@
 import { Account } from "../types/account"
-import { BaseListParams, Include, UnitConfig, UnitResponse } from "../types/common"
+import {BaseListParams, Include, Meta, UnitConfig, UnitResponse} from "../types/common"
 import { Customer } from "../types/customer"
-import { AchReceivedPayment, PatchPaymentRequest } from "../types/payments"
+import { AchReceivedPayment, PatchPaymentRequest, ReceivedPaymentStatus } from "../types/payments"
 import { Transaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
 
@@ -28,7 +28,7 @@ export class ReceivedPayments extends BaseResource {
         return this.httpGet<UnitResponse<AchReceivedPayment> & Include<Account[] | Customer[]>>(`/${id}`, { params })
     }
 
-    public async list(params?: ReceivedPaymentListParams): Promise<UnitResponse<AchReceivedPayment[]> & Include<Account[] | Customer[] | Transaction[]>> {
+    public async list(params?: ReceivedPaymentListParams): Promise<UnitResponse<AchReceivedPayment[]> & Include<Account[] | Customer[] | Transaction[]> & Meta> {
         const parameters: any = {
             "page[limit]": (params?.limit ? params.limit : 100),
             "page[offset]": (params?.offset ? params.offset : 0),
@@ -45,7 +45,7 @@ export class ReceivedPayments extends BaseResource {
                 parameters[`filter[status][${idx}]`] = s
             })
         
-        return this.httpGet<UnitResponse<AchReceivedPayment[]> & Include<Account[] | Customer[] | Transaction[]>>("", { params: parameters })
+        return this.httpGet<UnitResponse<AchReceivedPayment[]> & Include<Account[] | Customer[] | Transaction[]> & Meta>("", { params: parameters })
     }
 }
 
@@ -71,7 +71,7 @@ export interface ReceivedPaymentListParams extends BaseListParams {
     /**
      * Optional. Filter Received Payments by ReceivedPayment Status. Usage example: filter[status][0]=Pending&filter[status][1]=Advanced. cant be stated with includeCompleted.
      */
-    status?: string[]
+    status?: ReceivedPaymentStatus[]
 
     /**
      * Optional. Filter to include ReceivedPayment with Status 'Completed', default False. cant be stated with filter[status[]

--- a/types/events.ts
+++ b/types/events.ts
@@ -1,4 +1,5 @@
 import { Direction, HealthcareAmounts, Merchant, Relationship, Tags, UnimplementedFields, UnimplementedRelationships } from "./common"
+import {ReceivedPaymentStatus} from "./payments"
 
 export type UnitEvent = AccountEvents | ApplicationEvents | AuthorizationEvents | CardEvents | CustomerEvents | DocumentApproved | CheckDepositEvents |
  DocumentRejected | PaymentEvents | StatementsCreated | TransactionEvents | ChargeBackCreated | RewardEvents | DisputeEvents | BaseEvent
@@ -339,7 +340,7 @@ export type TransactionUpdated = BaseEvent & {
 export type ReceivedPaymentCreated = BaseEvent & {
     type: "receivedPayment.created"
     attributes: {
-        status: string
+        status: ReceivedPaymentStatus
         type: string
         amount: number
         completionDate: string
@@ -358,7 +359,7 @@ export type ReceivedPaymentCreated = BaseEvent & {
 export type ReceivedPaymentAdvanced = BaseEvent & {
     type: "receivedPayment.advanced"
     attributes: {
-        previousStatus: string
+        previousStatus: ReceivedPaymentStatus
         wasAdvanced: boolean
     }
     relationships: {
@@ -369,7 +370,7 @@ export type ReceivedPaymentAdvanced = BaseEvent & {
 export type ReceivedPaymentCompleted = BaseEvent & {
     type: "receivedPayment.completed"
     attributes: {
-        previousStatus: string
+        previousStatus: ReceivedPaymentStatus
         wasAdvanced: boolean
     }
     relationships: {
@@ -380,7 +381,7 @@ export type ReceivedPaymentCompleted = BaseEvent & {
 export type ReceivedPaymentReturned = BaseEvent & {
     type: "receivedPayment.returned"
     attributes: {
-        previousStatus: string
+        previousStatus: ReceivedPaymentStatus
         wasAdvanced: boolean
     }
     relationships: {

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -191,6 +191,8 @@ export interface BillPayment {
     relationships: BasePaymentRelationships
 }
 
+export type ReceivedPaymentStatus = "Pending" | "Advanced" | "Completed" | "Returned"
+
 export interface AchReceivedPayment {
     /**
      * Identifier of the received payment resource.
@@ -211,7 +213,7 @@ export interface AchReceivedPayment {
          * One of Pending, Advanced, Completed or Returned, see (ReceivedPayment Statuses)[https://docs.unit.co/received-ach/#statuses].
          * Common to all received payment types.
          */
-        status: "Pending" | "Advanced" | "Completed" | "Returned"
+        status: ReceivedPaymentStatus
 
         /**
          * Will be true if the received payment was or is being Advanced (has or has had the status Advanced).


### PR DESCRIPTION
This PR
- Corrects the return type for ReceivedPayments.list() by adding the pagination object
- Improves type-safety for keys referring to received payments status strings