### PR TITLE
Correct available authorization relationships on response

### DIFF
--- a/types/authorization.ts
+++ b/types/authorization.ts
@@ -62,11 +62,22 @@ export interface Authorization {
         /**
          * The customer the deposit account belongs to. The customer is either a business or a individual.
          */
-        customer: Relationship
+        customer?: Relationship
         
         /**
          * The debit card involved in the authorization.
          */
         card: Relationship
+
+        /**
+         * The list of Customers the deposit account belongs to. This relationship is only available if
+         * the account belongs to multiple individual customers.
+         */
+        customers?: Relationship
+
+        /**
+         * The preceding authorization request, if present (see docs.unit.co/cards-authorization-requests).
+         */
+        authorizationRequest?: Relationship
     }
 }

--- a/types/authorization.ts
+++ b/types/authorization.ts
@@ -1,4 +1,4 @@
-import { Merchant, Relationship } from "./common"
+import { Merchant, Relationship, UnimplementedRelationships } from "./common"
 
 export type AuthorizationStatus = "Authorized" | "Completed" | "Canceled" | "Declined"
 
@@ -79,5 +79,5 @@ export interface Authorization {
          * The preceding authorization request, if present (see docs.unit.co/cards-authorization-requests).
          */
         authorizationRequest?: Relationship
-    }
+    } & UnimplementedRelationships
 }


### PR DESCRIPTION
This PR correctly reflects the relationship object on the authorization resource as documented [here](https://docs.unit.co/resources#authorization).