### PR TITLE
Change `Event` type hierarchy for better Typescript support

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -1,7 +1,7 @@
 import { Direction, HealthcareAmounts, Merchant, Relationship, Tags, UnimplementedFields, UnimplementedRelationships } from "./common"
 
 export type UnitEvent = AccountEvents | ApplicationEvents | AuthorizationEvents | CardEvents | CustomerEvents | DocumentApproved | CheckDepositEvents |
- DocumentRejected | PaymentEvents | StatementsCreated | TransactionEvents | ChargeBackCreated | RewardEvents | DisputeEvents | BaseEvent
+ DocumentRejected | PaymentEvents | StatementsCreated | TransactionEvents | ChargeBackCreated | RewardEvents | DisputeEvents 
 
 export interface BaseEvent {
     id: string


### PR DESCRIPTION
Currently, the `UnitEvent` type is hard to work with because of the inheritance pattern from the current `BaseEvent` type. Because it defines a `type: string` the compiler is unable to effectively narrow the type when matching on the string literal for an event type, I.e.: 
```
const parseEvent = (event: UnitEvent): unknown => {
  if (event.type === 'account.closed') {
    const narrowedEvent: AccountClosed | BaseEvent = event;
    return narrowedEvent.attributes.closeReason;  // unknown
  }
};
```
By removing `BaseEvent`  from the union of possible events (`UnitEvent`), checking the type for the appropriate string literal will instead narrow to the correct type:
```
const parseEvent = (event: UnitEvent) => {
  if (event.type === 'account.closed') {
    const narrowedEvent: AccountClosed = event;
    return narrowedEvent.attributes.closeReason; // string
  }
  return undefined;
};
```

Seeing as every webhook event necessarily has an explicit value for the `type`, this meaningfully increases the DX as a Unit client seeing as it removes the need to do any `as` type assertions in order to satisfy the compiler.

Follows up on: https://github.com/unit-finance/unit-node-sdk/issues/197