### PR TITLE
Add fundingAccount and tags attributes on ApproveAuthorizationRequest

### DIFF
--- a/resources/authorizationRequest.ts
+++ b/resources/authorizationRequest.ts
@@ -40,7 +40,9 @@ export class AuthorizationRequests extends BaseResource {
         const data = {
             type: "approveAuthorizationRequest",
             attributes: {
-                amount: request.amount
+                amount: request.amount,
+                fundingAccount: request.fundingAccount,
+                tags: request.tags
             }
         }
         return await this.httpPost<UnitResponse<AuthorizationRequest>>(path, { data })

--- a/types/authorizationRequest.ts
+++ b/types/authorizationRequest.ts
@@ -137,8 +137,27 @@ type AuthorizationRequesBaseRelationships = {
 
 
 export interface ApproveAuthorizationRequest {
+    /**
+     * Identifier of the card transaction authorization request resource.
+     */
     id: string
+
+    /**
+     * Optional. The approved amount (in cents). 
+     * Can only be specified if the authorization request's partialApprovalAllowed is set to true.
+     */
     amount?: number
+
+    /**
+     * Optional. The id of an alternate account (either the customer's or another's) that should be used for funding the transaction. 
+     * Please contact Unit to enable this feature.
+     */
+    fundingAccount?: string
+
+    /**
+     * Optional. See Tags.
+     */
+    tags?: object
 }
 
 


### PR DESCRIPTION
Add optional attributes to `ApproveAuthorizationRequest` to support selecting a `fundingAccount` to be used for funding the `Card Purchase Transaction`

Relevant API docs:
https://docs.unit.co/cards-authorization-requests#approve-authorization-request