### PR TITLE
Pass an empty body for enable/disable recurring payments

### DIFF
--- a/resources/recurringPayments.ts
+++ b/resources/recurringPayments.ts
@@ -12,11 +12,27 @@ export class RecurringPayments extends BaseResource {
     }
 
     public async disable(paymentId: string): Promise<UnitResponse<RecurringPayment>> {
-        return this.httpPost<UnitResponse<RecurringPayment>>(`/${paymentId}/disable`)
+        // NB: We must pass an empty body here because the API is returning a 415 for any requests made
+        //  to this endpoint from this SDK: Content-Type must be application/vnd.api+json
+        //  However, there is code in Axios that strips the Content-Type from the request whenever 
+        //  there is no body since it makes no sense to provide it + makes the data over the wire
+        //  that much smaller:  
+        //   https://github.com/axios/axios/blob/649d739288c8e2c55829ac60e2345a0f3439c730/dist/axios.js#L1449-L1450
+        // TODO: Remove the empty body after we update the API to not throw 415 for missing Content-Type 
+        //  when the body is empty.
+        return this.httpPost<UnitResponse<RecurringPayment>>(`/${paymentId}/disable`, { data: {} })
     }
 
     public async enable(paymentId: string): Promise<UnitResponse<RecurringPayment>> {
-        return this.httpPost<UnitResponse<RecurringPayment>>(`/${paymentId}/enable`)
+        // NB: We must pass an empty body here because the API is returning a 415 for any requests made
+        //  to this endpoint from this SDK: Content-Type must be application/vnd.api+json
+        //  However, there is code in Axios that strips the Content-Type from the request whenever 
+        //  there is no body since it makes no sense to provide it + makes the data over the wire
+        //  that much smaller:  
+        //   https://github.com/axios/axios/blob/649d739288c8e2c55829ac60e2345a0f3439c730/dist/axios.js#L1449-L1450
+        // TODO: Remove the empty body after we update the API to not throw 415 for missing Content-Type 
+        //  when the body is empty.
+        return this.httpPost<UnitResponse<RecurringPayment>>(`/${paymentId}/enable`, { data: {} })
     }
 
     public async get(paymentId: string): Promise<UnitResponse<RecurringPayment>> {


### PR DESCRIPTION
We were getting an error from the API saying that we weren't
providing the correct Content-Type. However, we were generating
the request from the SDK so we stepped through how the request
was being created on the SDK-side of things and found that the
headers were being stripped from within Axios:
    https://github.com/axios/axios/blob/649d739288c8e2c55829ac60e2345a0f3439c730/dist/axios.js#L1449-L1450

After some discussion, the correct solution would be to update
the API to not require a Content-Type header whenever there is
no body since it's not necessary, and is a waste of bytes over
the wire.

The current patch to the SDK is a temporary fix until we remove
the restriction from the API.

Full context: https://highbeamco.slack.com/archives/C02JB5M1599/p1660766477125359