### PR TITLE
Get Mobile Wallet Payload

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -1,4 +1,4 @@
-import { AddAuthorizedUsersRequest, RemoveAuthorizedUsersRequest } from "./types"
+import { AddAuthorizedUsersRequest, MobileWalletPayloadRequest, RemoveAuthorizedUsersRequest } from "./types"
 import { State, Address, FullName, Phone, Status, Title, Officer, BeneficialOwner, BusinessContact, AuthorizedUser, Counterparty, Coordinates, UsAddress, InternationalAddress, Relationship, RelationshipsArrayData } from "./types/common"
 export function createUsAddress(street: string, street2: string | null, city: string, state: State | null, postalCode: string, country: "US"): UsAddress {
     return {
@@ -142,6 +142,18 @@ export function createRemoveAuthorizedUsersRequest(customerId: string, authorize
                 authorizedUsersEmails
             }
         }
+    }
+}
+
+export function createMobileWalletRequest(cardId: string, signedNonce: string): MobileWalletPayloadRequest {
+    return {
+        cardId,
+        data: {
+            attributes: {
+                signedNonce
+            }
+        }
+
     }
 }
 

--- a/resources/baseResource.ts
+++ b/resources/baseResource.ts
@@ -73,6 +73,19 @@ export class BaseResource {
             .catch(error => { throw extractUnitError(error) })
     }
 
+    protected async httpPostFullPath<T>(path: string, data?: DataPayload | { data: object; }, config?: { headers?: object; params?: object; }): Promise<T> {
+        const conf = {
+            headers: this.mergeHeaders(config?.headers),
+            maxBodyLength: MAX_REQUEST_SIZE,
+            maxContentLength: MAX_REQUEST_SIZE,
+            ...(config?.params && { params: (config.params) })
+        }
+
+        return await this.axios.post<T>(path, data, conf)
+            .then(r => r.data)
+            .catch(error => { throw extractUnitError(error) })
+    }
+
     protected async httpPut<T>(path: string, data: object | Buffer, config?: { headers?: object; params?: object; }): Promise<T> {
         const conf = {
             headers: this.mergeHeaders(config?.headers),

--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -6,8 +6,13 @@ import { BaseResource } from "./baseResource"
 
 export class Cards extends BaseResource {
 
-    constructor(token: string, basePath: string, config?: UnitConfig) {
+    securePath = "https://secure.api.s.unit.sh"
+    appId = "b8186bd9-fcba-b77a-11e3-1c0d2e5a3501"
+
+    constructor(token: string, basePath: string, config?: UnitConfig, appId?: string) {
         super(token, basePath + "/cards", config)
+        if(appId)
+            this.appId = appId
     }
 
     public async createDebitCard(request: CreateDebitCardRequest): Promise<UnitResponse<Card>> {
@@ -89,7 +94,13 @@ export class Cards extends BaseResource {
     }
 
     public async mobileWalletPayload(cardId: string, request: MobileWalletPayloadRequest): Promise<UnitResponse<MobileWalletPayload>> {
-        return await this.httpPost<UnitResponse<MobileWalletPayload>>(`/${cardId}`, {data: request})
+        return await this.httpPostFullPath<UnitResponse<MobileWalletPayload>>
+        (`${this.securePath}/cards/${cardId}/mobile-wallet-payload`, {data: request})
+    }
+
+    
+    public async setAppId(appId: string){
+        this.appId = appId
     }
 
 }

--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -7,12 +7,9 @@ import { BaseResource } from "./baseResource"
 export class Cards extends BaseResource {
 
     securePath = "https://secure.api.s.unit.sh"
-    appId = "b8186bd9-fcba-b77a-11e3-1c0d2e5a3501"
 
-    constructor(token: string, basePath: string, config?: UnitConfig, appId?: string) {
+    constructor(token: string, basePath: string, config?: UnitConfig) {
         super(token, basePath + "/cards", config)
-        if(appId)
-            this.appId = appId
     }
 
     public async createDebitCard(request: CreateDebitCardRequest): Promise<UnitResponse<Card>> {
@@ -93,14 +90,9 @@ export class Cards extends BaseResource {
         return await this.httpPatch<UnitResponse<Card>>(`/${request.id}`, request)
     }
 
-    public async mobileWalletPayload(cardId: string, request: MobileWalletPayloadRequest): Promise<UnitResponse<MobileWalletPayload>> {
+    public async mobileWalletPayload(request: MobileWalletPayloadRequest): Promise<UnitResponse<MobileWalletPayload>> {
         return await this.httpPostFullPath<UnitResponse<MobileWalletPayload>>
-        (`${this.securePath}/cards/${cardId}/mobile-wallet-payload`, {data: request})
-    }
-
-    
-    public async setAppId(appId: string){
-        this.appId = appId
+        (`${this.securePath}/cards/${request.cardId}/mobile-wallet-payload`, {data: request.data})
     }
 
 }

--- a/types/cards.ts
+++ b/types/cards.ts
@@ -431,8 +431,12 @@ export interface MobileWalletPayload {
 }
 
 export interface MobileWalletPayloadRequest {
-    attributes: {
-        signedNonce: string
+    cardId: string
+    
+    data: {
+        attributes: {
+            signedNonce: string
+        }
     }
 }
 


### PR DESCRIPTION
made some changes to GetMobileWalletPayload. The right path is "https://secure.api.s.unit.sh/cards/:id/mobile-wallet-payload",
you can read more about it [here](https://developers.unit.co/cards-add-to-mobile-wallet/#get-mobile-wallet-payload)

- MobileWalletRequest contains the cardId now
-I've also added createMobileWalletRequest helpers function
  you can use it like this:
  `const res = await unit.cards.mobileWalletPayload(createMobileWalletRequest(cardId, signedNonce))`
      