### PR TITLE
Remove `counterparty` nullability for `RecurringCreditAchPayment` and `RecurringCreditBookPayment`

### DIFF
--- a/types/recurringPayment.ts
+++ b/types/recurringPayment.ts
@@ -96,7 +96,7 @@ export interface RecurringCreditAchPayment {
         /**
          * The Counterparty the payment to be made to.
          */
-        counterparty?: Relationship
+        counterparty: Relationship
     } & RecurringPaymentRelationships
 }
 
@@ -128,7 +128,7 @@ export interface RecurringCreditBookPayment {
         /**
          * The Counterparty account the payment to be made to.
          */
-        counterpartyAccount?: Relationship
+        counterpartyAccount: Relationship
     } & RecurringPaymentRelationships
 }
 
@@ -226,7 +226,7 @@ export interface CreateRecurringCreditAchPaymentRequest {
         /**
          * The Counterparty the payment to be made to.
          */
-        counterparty?: Relationship
+        counterparty: Relationship
     }
 }
 
@@ -255,7 +255,7 @@ export interface CreateRecurringCreditBookPaymentRequest {
         /**
          * The Counterparty account to which the payment will be made.
          */
-        counterpartyAccount?: Relationship
+        counterpartyAccount: Relationship
     }
 }
 


### PR DESCRIPTION
In the Unit docs for [creating a recurring ACH payment](https://docs.unit.co/recurring-payments/#recurring-payment-credit-ach-payment) and [creating a recurring book payment](https://docs.unit.co/recurring-payments/#recurring-credit-book-payment), `counterparty` and `counterpartyAccount` are listed as required fields under `Relationships`. However, currently these properties are nullable. 

This PR makes a small update to ensure recurring payments (both `RecurringCreditAchPayment` and `RecurringCreditBookPayment`) require a counterparty by removing nullability on these fields. This makes sense logically as having a recurring payment without a counterparty is an invalid state. 

This is the same requirement for the `AchPayment` and `BookPayment` Payment types. 