### PR TITLE
Enable to card to card payment is implemented

### DIFF
--- a/resources/cards.ts
+++ b/resources/cards.ts
@@ -1,4 +1,6 @@
-import {Card, CardLimits, CreateDebitCardRequest, MobileWalletPayload, MobileWalletPayloadRequest, PinStatus, ReplaceCardRequest, UpdateCardRequest} from "../types/cards"
+import {
+    Card, CardLimits, CreateDebitCardRequest, EnableCardToCardPaymentRequest, EnableCardToCardPaymentResponse, MobileWalletPayload, MobileWalletPayloadRequest, PinStatus, ReplaceCardRequest, UpdateCardRequest
+} from "../types/cards"
 import { BaseListParams, Include, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
@@ -96,6 +98,12 @@ export class Cards extends BaseResource {
         return await this.httpPostFullPath<UnitResponse<MobileWalletPayload>>
         (`${this.securePath}/cards/${request.cardId}/mobile-wallet-payload`, {data: request.data})
     }
+
+    public async enableCardToCardPayments(request: EnableCardToCardPaymentRequest): Promise<UnitResponse<EnableCardToCardPaymentResponse>> {
+        return await this.httpPatch<UnitResponse<EnableCardToCardPaymentResponse>>
+        (`/${request.cardId}/enableCardToCardPayment`, {data: request.data})
+    }
+
 
 }
 

--- a/types/cards.ts
+++ b/types/cards.ts
@@ -447,6 +447,26 @@ export interface MobileWalletPayloadRequest {
     }
 }
 
+export interface EnableCardToCardPaymentResponse {
+    type: "astra"
+    id: string
+    attributes: {
+        astraCardId: string
+    }
+}
+
+export interface EnableCardToCardPaymentRequest {
+    cardId: string
+
+    data: {
+        type: "astra"
+        attributes: {
+            token: string
+            idempotencyKey?: string
+        }
+    }
+}
+
 interface BaseUpdateAttributes extends UnimplementedFields {
     /**
      * Optional. See [Updating Tags](https://docs.unit.co/#updating-tags).


### PR DESCRIPTION
With the new partner **Astra** the new endpoint added to api, which is `Enable Card To Card Payments Using Astra`.
Also regarding documentation following link may be helpful: 
https://guides.unit.co/partnerships/astra/#enable-card-to-card-payments-using-astra

Since it is mentioned in guides section it may not be seen before but it is a working endpoint. 