### PR TITLE
add missing properties in transaction.created event

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -383,6 +383,8 @@ export type TransactionCreated = BaseEvent & {
         summary: string
         direction: Direction
         amount: number
+        available: number
+        balance: number
     }
     relationships: {
         transaction: Relationship


### PR DESCRIPTION
According to [docs](https://docs.unit.co/events/#transactioncreated), `balance` and `available` properties are also included in the event (they also are when looking at what is sent to us).