### PR TITLE
Send batch release with array of requests

### DIFF
--- a/resources/batchAccounts.ts
+++ b/resources/batchAccounts.ts
@@ -41,6 +41,11 @@ export interface CreateBatchReleaseRequest {
         senderAccountNumber: string
 
         /**
+         * See [Idempotency](https://docs.unit.co/#intro-idempotency).
+         */
+        idempotencyKey?: string
+
+        /**
          * See Tags will be passed to the related Release Transaction.
          */
         tags?: object

--- a/resources/batchAccounts.ts
+++ b/resources/batchAccounts.ts
@@ -7,8 +7,8 @@ export class BatchAccounts extends BaseResource {
         super(token, basePath + "/batch-releases", config)
     }
 
-    public async create(request: CreateBatchReleaseRequest[]): Promise<UnitResponse<BatchRelease>> {
-        return this.httpPost<UnitResponse<BatchRelease>>("", { data: request })
+    public async create(request: CreateBatchReleaseRequest[]): Promise<UnitResponse<BatchRelease[]>> {
+        return this.httpPost<UnitResponse<BatchRelease[]>>("", { data: request })
     }
 }
 

--- a/resources/batchAccounts.ts
+++ b/resources/batchAccounts.ts
@@ -7,12 +7,12 @@ export class BatchAccounts extends BaseResource {
         super(token, basePath + "/batch-releases", config)
     }
 
-    public async create(request: CraeteBatchReleaseRequest): Promise<UnitResponse<BatchRelease>> {
+    public async create(request: CreateBatchReleaseRequest[]): Promise<UnitResponse<BatchRelease>> {
         return this.httpPost<UnitResponse<BatchRelease>>("", { data: request })
     }
 }
 
-export interface CraeteBatchReleaseRequest {
+export interface CreateBatchReleaseRequest {
     type: "batchRelease"
     attributes: {
         /**


### PR DESCRIPTION
Related PR https://github.com/unit-finance/unit-node-sdk/pull/276

Batch Releases accept an array of requests per docs: https://docs.unit.co/batch-payments#create-batch-releases

This PR changes the BatchRelease `create` method parameter/return types so they are consistent with the docs