### PR TITLE
Add surcharge to AuthorizationRequestPending type definition

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -162,6 +162,7 @@ export type AuthorizationRequestPending = BaseEvent & {
         ecommerce?: boolean
         cardPresent?: boolean
         healthcareAmounts?: HealthcareAmounts
+        surcharge?: number
     }
     relationships: AuthorizationRequestRelationships
 }


### PR DESCRIPTION
We encountered an issue when consuming webhooks from Unit with this SDK. The current type definition of `AuthorizationRequestPending` does not include `surcharge` in its `attributes`. Copied to the bottom of this description is a payload we received recently where there is a surcharge included with the authorization request (with some info replaced with dots since this a public repo).

Notably, I believe `internationalServiceFee` is also missing from the type definition and could be something that we'd want as well given that this would incur additional costs that we would be worried about. However, I leave that from the scope of this PR as I am trying to address a very narrow issue.

```
{
    "data": {
        "id": ".......",
        "type": "authorizationRequest.pending",
        "attributes": {
            "createdAt": "......",
            "amount": 500,
            "available": ......,
            "status": "Pending",
            "partialApprovalAllowed": false,
            "direction": "Debit",
            "atmName": "......",
            "surcharge": 350,
            "mustBeApproved": false,
            "atmLocation": "......",
            "internationalServiceFee": 0
        },
        "relationships": {
            "authorizationRequest": {
                "data": {
                    "id": ".......",
                    "type": "atmAuthorizationRequest"
                }
            },
            "account": {
                "data": {
                    "id": ".......",
                    "type": "account"
                }
            },
            "customer": {
                "data": {
                    "id": "......",
                    "type": "customer"
                }
            },
            "card": {
                "data": {
                    "id": ".......",
                    "type": "card"
                }
            }
        }
    }
}
```