### PR TITLE
Feature: Update application fields for new due diligence requirements

### DIFF
--- a/tests/testHelpers.ts
+++ b/tests/testHelpers.ts
@@ -9,8 +9,10 @@ export function createIndividualApplication(unit: Unit) {
             fullName: createFullName("Richard", "Hendricks"),
             dateOfBirth: "2001-08-10",
             address: createAddress("20 Ingram St", null, "Forest Hills", "CA", "11375", "US"),
+            nationality: "US",
             email: "april@baxter.com",
-            phone: createPhone("1", "5555555555")
+            phone: createPhone("1", "5555555555"),
+            occupation: "GigWorker"
         }
     }
 
@@ -25,8 +27,10 @@ export function createIndividualApplicationWithRequiredDocument(unit: Unit) {
             fullName: createFullName("Richard", "Hendricks"),
             dateOfBirth: "2001-08-10",
             address: createAddress("20 Ingram St", null, "Forest Hills", "CA", "11375", "US"),
+            nationality: "US",
             email: "april@baxter.com",
-            phone: createPhone("1", "5555555555")
+            phone: createPhone("1", "5555555555"),
+            occupation: "GigWorker"
         }
     }
 
@@ -41,8 +45,10 @@ export function createIndividualApplicationWithSelfieVerification(unit: Unit) {
             fullName: createFullName("Richard", "Hendricks"),
             dateOfBirth: "2001-08-10",
             address: createAddress("20 Ingram St", null, "Forest Hills", "CA", "11375", "US"),
+            nationality: "US",
             email: "april@baxter.com",
             phone: createPhone("1", "5555555555"),
+            occupation: "GigWorker",
             evaluationParams: {
                 "useSelfieVerification": "ReplaceIdentification"
             }

--- a/types/application.ts
+++ b/types/application.ts
@@ -1,5 +1,5 @@
 import {responseEncoding, ResponseType} from "axios"
-import { Address, BeneficialOwner, BusinessContact, FullName, Officer, Phone, State, Relationship, DeviceFingerprint, Agent, RelationshipsArray, Beneficiary, Grantor, TrustContact, Trustee, UnimplementedRelationships, UnimplementedFields, EvaluationParams, Industry } from "./common"
+import { Address, BeneficialOwner, BusinessContact, FullName, Officer, Phone, State, Relationship, DeviceFingerprint, Agent, RelationshipsArray, Beneficiary, Grantor, TrustContact, Trustee, UnimplementedRelationships, UnimplementedFields, EvaluationParams, Industry, Occupation, AnnualIncome, SourceOfIncome } from "./common"
 
 /**
  * see [Application Statuses](https://docs.unit.co/applications/#application-statuses).
@@ -98,10 +98,10 @@ export interface IndividualApplication extends BaseApplication {
         passport?: string
 
         /**
-         * Required on passport only. Two letters representing the individual nationality.
+         * Two letters representing the individual nationality.
          * ISO31661 - Alpha2 format. For more information: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
          */
-        nationality?: string
+        nationality: string
 
         /**
          * Full name of the individual.
@@ -128,6 +128,21 @@ export interface IndividualApplication extends BaseApplication {
          * Email address of the individual.
          */
         email: string
+
+        /**
+         * Occupation of the individual.
+         */
+        occupation: Occupation
+
+        /**
+         * Required for non-US nationalities. Annual income of the individual.
+         */
+        annualIncome?: AnnualIncome
+
+        /**
+         * Required for non-US nationalities. Source of income of the individual.
+         */
+        sourceOfIncome?: SourceOfIncome
 
         /**
          * IP address of the end-customer creating the application, if specified.
@@ -392,10 +407,10 @@ export interface CreateIndividualApplicationRequest {
         passport?: string
 
         /**
-         * Required on passport only. Two letters representing the individual nationality.
+         * Two letters representing the individual nationality.
          * ISO31661-Alpha2
          */
-        nationality?: string
+        nationality: string
 
         /**
          * Full name of the individual.
@@ -421,6 +436,21 @@ export interface CreateIndividualApplicationRequest {
          * Email address of the individual.
          */
         email: string
+
+        /**
+         * Occupation of the individual.
+         */
+        occupation: Occupation
+
+        /**
+         * Required for non-US nationalities. Annual income of the individual.
+         */
+        annualIncome?: AnnualIncome
+
+        /**
+         * Required for non-US nationalities. Source of income of the individual.
+         */
+        sourceOfIncome?: SourceOfIncome
 
         /**
          * IP address of the end - customer creating the application.

--- a/types/applicationForm.ts
+++ b/types/applicationForm.ts
@@ -1,4 +1,4 @@
-import { Address, BeneficialOwner, BusinessContact, FullName, Officer, Phone, Relationship } from "./common"
+import { Address, BeneficialOwner, BusinessContact, FullName, Officer, Phone, Relationship, Occupation, AnnualIncome, SourceOfIncome } from "./common"
 
 export type ApplicationFormStage =
     "ChooseBusinessOrIndividual" |
@@ -108,6 +108,18 @@ export interface ApplicationFormPrefill {
      * Individual. Optional. Email address of the individual.
      */
     email?: string
+    /**
+     * Individual. Optional. Occupation of the individual.
+     */
+    occupation?: Occupation
+    /**
+     * Individual. Optional. Annual income of the individual.
+     */
+    annualIncome?: AnnualIncome
+    /**
+     * Individual. Optional. Annual income of the individual.
+     */
+    sourceOfIncome?: SourceOfIncome
     /**
      * Business. Optional. Name of the business.
      */

--- a/types/common.ts
+++ b/types/common.ts
@@ -50,6 +50,47 @@ export type State = "AL" | "AK" | "AZ" | "AR" | "CA" | "CO" | "CT" | "DE" | "FL"
     | "PR" // Puerto Rico
     | "VI" // Virgin Islands
 
+export type Occupation =
+    "ArchitectOrEngineer" |
+    "BusinessAnalystAccountantOrFinancialAdvisor" |
+    "CommunityAndSocialServicesWorker" |
+    "ConstructionMechanicOrMaintenanceWorker" |
+    "Doctor" |
+    "Educator" |
+    "EntertainmentSportsArtsOrMedia" |
+    "ExecutiveOrManager" |
+    "FarmerFishermanForester" |
+    "FoodServiceWorker" |
+    "GigWorker" |
+    "HospitalityOfficeOrAdministrativeSupportWorker" |
+    "HouseholdManager" |
+    "JanitorHousekeeperLandscaper" |
+    "Lawyer" |
+    "ManufacturingOrProductionWorker" |
+    "MilitaryOrPublicSafety" |
+    "NurseHealthcareTechnicianOrHealthcareSupport" |
+    "PersonalCareOrServiceWorker" |
+    "PilotDriverOperator" |
+    "SalesRepresentativeBrokerAgent" |
+    "ScientistOrTechnologist" |
+    "Student"
+
+export type AnnualIncome =
+    "UpTo10k" |
+    "Between10kAnd25k" |
+    "Between25kAnd50k" |
+    "Between50kAnd100k" |
+    "Between100kAnd250k" |
+    "Over250k"
+    
+export type SourceOfIncome =
+    "EmploymentOrPayrollIncome" |
+    "PartTimeOrContractorIncome" |
+    "InheritancesAndGifts" |
+    "PersonalInvestments" |
+    "BusinessOwnershipInterests" |
+    "GovernmentBenefits"
+
 export interface FullName {
     /**
      * 	Individual first name.


### PR DESCRIPTION
Occupation and nationality are required fields. Source of income and annual income are only required for non-US nationals. Unit hasn't given a timeline for when they'll make these changes, but the requirements will be in force by the end of May.