### PR TITLE
Add prepare script so build runs when npm installing a fork of the repo directly from Github

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "jest .spec.ts --maxWorkers=1 --no-cache",
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint **/*.ts",
-    "lint-fix": "eslint **/*.ts --fix"
+    "lint-fix": "eslint **/*.ts --fix",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["tests/*"]
+  "exclude": [
+    "tests/*",
+    "dist"
+  ]
 }


### PR DESCRIPTION
If someone is using `unit-node-sdk`, and wants to contribute to this repo (like I'm trying to do), they likely need to:

1. Fork the repo
2. `npm rm --save @unit-finance/unit-node-sdk` (to remove the official sdk)
3. `npm i --save git+https://github.com/{ORG_NAME}/unit-node-sdk.git#{BRANCH_NAME}` (to depend on the fork)

But the problem is that the `dist` folder isn't included in the source, so cloning the repo isn't enough. `build` needs to run.
These changes use `prepare` to make `build` run when we do the `npm install`.

I also added `dist` to the exclude list to stop the TS5055 errors that happen when running `npm run build`
https://stackoverflow.com/a/48798945/4975772

I'm not sure what the build process is like for distributing to npm, so hopefully this doesn't conflict with how that works. I'm happy to help fix any issues!