### PR TITLE
Add support for receive ACH payment simulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "jest .spec.ts --maxWorkers=1 --no-cache",
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint **/*.ts",
-    "lint-fix": "eslint **/*.ts --fix"
+    "lint-fix": "eslint **/*.ts --fix",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/resources/simulations.ts
+++ b/resources/simulations.ts
@@ -1,11 +1,12 @@
 import { BaseResource } from "."
 import { UnitConfig, UnitResponse } from "../types"
-import { AchReceivedPayment, Application, ApplicationDocument } from "../types"
+import { AchReceivedPayment, Application, ApplicationDocument, AchPayment } from "../types"
 import {
     ApproveApplicationSimulation,
     DenyApplicationSimulation,
     RejectDocumentSimulation,
     CreateAchReceivedPaymentSimulation,
+    ReceiveAchPaymentSimulation,
 } from "../types"
 
 export class Simulations extends BaseResource {
@@ -54,6 +55,17 @@ export class Simulations extends BaseResource {
     ): Promise<UnitResponse<ApplicationDocument>> {
         return this.httpPost<UnitResponse<ApplicationDocument>>(
             `/applications/${applicationId}/documents/${documentId}/reject`,
+            {
+                data: request,
+            }
+        )
+    }
+
+    public async receiveAchPayment(
+        request: ReceiveAchPaymentSimulation
+    ): Promise<UnitResponse<AchPayment>> {
+        return this.httpPost<UnitResponse<AchPayment>>(
+            "/payments",
             {
                 data: request,
             }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["tests/*"]
+  "exclude": [
+    "tests/*",
+    "dist"
+  ]
 }

--- a/types/simulations.ts
+++ b/types/simulations.ts
@@ -31,8 +31,10 @@ export interface ReceiveAchPaymentSimulation {
     }
     relationships: {
         account: {
-            type: "depositAccount"
-            id: string
+            data: {
+                type: "depositAccount"
+                id: string
+            }
         }
     }
 }


### PR DESCRIPTION
This adds support for the [Receive ACH payment simulation](https://docs.unit.co/simulations/#simulate-receive-ach-payment) This is different from the (already supported, and confusingly similarly named) [Create ACH Received Payment](https://docs.unit.co/simulations/#simulate-ach-received-payment) 

This PR has two commits because it's stacked on top of [my other PR](https://github.com/unit-finance/unit-node-sdk/pull/355) If that one gets merged in, I can reduce this down to just one commit.