### PR TITLE
Add support for create transaction simulation

### DIFF
--- a/resources/simulations.ts
+++ b/resources/simulations.ts
@@ -7,6 +7,8 @@ import {
     RejectDocumentSimulation,
     CreateAchReceivedPaymentSimulation,
     ReceiveAchPaymentSimulation,
+    CreateCardPurchaseSimulation,
+    CardTransaction,
 } from "../types"
 
 export class Simulations extends BaseResource {
@@ -89,5 +91,13 @@ export class Simulations extends BaseResource {
         return this.httpPost<UnitResponse<AchReceivedPayment>>(
             `/received-payments/${id}/complete`,
         )
+    }
+
+    public async createCardPurchase(
+        request: CreateCardPurchaseSimulation
+    ): Promise<UnitResponse<CardTransaction>> {
+        return this.httpPost<UnitResponse<CardTransaction>>("/purchases", {
+            data: request,
+        });
     }
 }

--- a/types/simulations.ts
+++ b/types/simulations.ts
@@ -112,19 +112,20 @@ export interface CreateCardPurchaseSimulation {
     type: "purchaseTransaction"
     attributes: {
         amount: number
-        direction: string
+        direction: "Credit" | "Debit"
         merchantName: string
         /**
          * The 4-digit ISO 18245 merchant category code (MCC). Use any number (e.g. 1000 for testing).
          */
         merchantType: number
-        merchantLocation: string
+        merchantLocation?: string
+        merchantId?: string
+        last4Digits: string
         coordinates?: {
             longitude: number
             latitude: number
         }
-        last4Digits: string
-        recurring: false
+        recurring?: false
     }
     relationships: {
         account: {


### PR DESCRIPTION
This adds support for the simulation endpoint shown in the docs here: https://docs.unit.co/simulations#simulate-card-purchase

I also edited the actual payload to better line up with the docs. I made a bunch of fields optional.