### PR TITLE
function to update book/chargeback transactions

### DIFF
--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -66,9 +66,14 @@ export class Transactions extends BaseResource {
      * @param tags - See [Updating Tags](https://developers.unit.co/#tags).
      * @returns
      */
-    public async update(request: PatchTransactionRequest): Promise<UnitResponse<Transaction>> {
+    public async updateTags(request: PatchTransactionRequest): Promise<UnitResponse<Transaction>> {
         return await this.httpPatch<UnitResponse<Transaction>>(`/accounts/${request.accountId}/transactions/${request.transactionId}`,{ data: request.data })
     }
+
+    public async update(request: PatchTransactionRequest): Promise<UnitResponse<Transaction>> {
+        return await this.httpPatch<UnitResponse<Transaction>>(`/transactions/${request.transactionId}`,{ data: request.data })
+    }
+
 }
 
 export interface TransactionListParams extends BaseListParams {

--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -1,7 +1,7 @@
 import { BaseListParams, Include, Meta, Sort, Tags, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
-import { PatchTransactionRequest, Transaction } from "../types/transactions"
+import { PatchTransactionRequest, Transaction, PatchBookOrChargebackRequest } from "../types/transactions"
 import { BaseResource } from "./baseResource"
 
 export class Transactions extends BaseResource {
@@ -60,17 +60,22 @@ export class Transactions extends BaseResource {
     }
 
     /**
-     *
+     * Update a Transaction
      * @param accountId
      * @param transactionId
      * @param tags - See [Updating Tags](https://developers.unit.co/#tags).
      * @returns
      */
-    public async updateTags(request: PatchTransactionRequest): Promise<UnitResponse<Transaction>> {
+    public async update(request: PatchTransactionRequest): Promise<UnitResponse<Transaction>> {
         return await this.httpPatch<UnitResponse<Transaction>>(`/accounts/${request.accountId}/transactions/${request.transactionId}`,{ data: request.data })
     }
 
-    public async update(request: PatchTransactionRequest): Promise<UnitResponse<Transaction>> {
+    /**
+     *  Update a Book or Chargeback Transaction
+     * @param request 
+     * @returns 
+     */
+    public async updateBookOrChargeback(request: PatchBookOrChargebackRequest): Promise<UnitResponse<Transaction>> {
         return await this.httpPatch<UnitResponse<Transaction>>(`/transactions/${request.transactionId}`,{ data: request.data })
     }
 

--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -1,7 +1,7 @@
 import { BaseListParams, Include, Meta, Sort, Tags, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
-import { PatchTransactionRequest, Transaction, PatchBookOrChargebackRequest } from "../types/transactions"
+import { PatchBookOrChargebackRequest, PatchTransactionRequest, Transaction, } from "../types/transactions"
 import { BaseResource } from "./baseResource"
 
 export class Transactions extends BaseResource {
@@ -60,7 +60,7 @@ export class Transactions extends BaseResource {
     }
 
     /**
-     * Update a Transaction
+     *
      * @param accountId
      * @param transactionId
      * @param tags - See [Updating Tags](https://developers.unit.co/#tags).
@@ -70,11 +70,6 @@ export class Transactions extends BaseResource {
         return await this.httpPatch<UnitResponse<Transaction>>(`/accounts/${request.accountId}/transactions/${request.transactionId}`,{ data: request.data })
     }
 
-    /**
-     *  Update a Book or Chargeback Transaction
-     * @param request 
-     * @returns 
-     */
     public async updateBookOrChargeback(request: PatchBookOrChargebackRequest): Promise<UnitResponse<Transaction>> {
         return await this.httpPatch<UnitResponse<Transaction>>(`/transactions/${request.transactionId}`,{ data: request.data })
     }

--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -1,7 +1,7 @@
 import { BaseListParams, Include, Meta, Sort, Tags, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
-import { PatchBookOrChargebackRequest, PatchTransactionRequest, Transaction, } from "../types/transactions"
+import { PatchBookOrChargebackRequest, PatchTransactionRequest, Transaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
 
 export class Transactions extends BaseResource {

--- a/resources/transactions.ts
+++ b/resources/transactions.ts
@@ -1,7 +1,7 @@
 import { BaseListParams, Include, Meta, Sort, Tags, UnitConfig, UnitResponse } from "../types/common"
 import { Customer } from "../types/customer"
 import { Account } from "../types/account"
-import { PatchBookOrChargebackRequest, PatchTransactionRequest, Transaction } from "../types/transactions"
+import { PatchTransactionWithRelationshipsRequest, PatchTransactionRequest, Transaction } from "../types/transactions"
 import { BaseResource } from "./baseResource"
 
 export class Transactions extends BaseResource {
@@ -70,7 +70,7 @@ export class Transactions extends BaseResource {
         return await this.httpPatch<UnitResponse<Transaction>>(`/accounts/${request.accountId}/transactions/${request.transactionId}`,{ data: request.data })
     }
 
-    public async updateBookOrChargeback(request: PatchBookOrChargebackRequest): Promise<UnitResponse<Transaction>> {
+    public async updateWithRelationships(request: PatchTransactionWithRelationshipsRequest): Promise<UnitResponse<Transaction>> {
         return await this.httpPatch<UnitResponse<Transaction>>(`/transactions/${request.transactionId}`,{ data: request.data })
     }
 

--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -931,6 +931,3 @@ export type PatchTransactionWithRelationshipsRequest = {
         }
     }
 }
-
-
-

--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -912,16 +912,12 @@ export type PatchTransactionRequest = {
     data: {
         type: "transaction"
         attributes: {
-            summary?: string
             tags?: Tags
-        }
-        relationships?: {
-            account?: Relationship
         }
     }
 }
 
-export type PatchBookOrChargebackRequest = {
+export type PatchTransactionWithRelationshipsRequest = {
     transactionId: string
     
     data: {

--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -931,3 +931,4 @@ export type PatchTransactionWithRelationshipsRequest = {
         }
     }
 }
+

--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -930,8 +930,8 @@ export type PatchBookOrChargebackRequest = {
             summary?: string
             tags?: Tags
         }
-        relationships?: {
-            account?: Relationship
+        relationships: {
+            account: Relationship
         }
     }
 }

--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -910,7 +910,7 @@ export type PatchTransactionRequest = {
     transactionId: string
     
     data: {
-        type: "transaction" | "bookTransaction" | "chargebackTransaction"
+        type: "transaction"
         attributes: {
             summary?: string
             tags?: Tags
@@ -920,4 +920,21 @@ export type PatchTransactionRequest = {
         }
     }
 }
+
+export type PatchBookOrChargebackRequest = {
+    transactionId: string
+    
+    data: {
+        type: "bookTransaction" | "chargebackTransaction"
+        attributes: {
+            summary?: string
+            tags?: Tags
+        }
+        relationships?: {
+            account?: Relationship
+        }
+    }
+}
+
+
 


### PR DESCRIPTION
Fix bugged url in `update` which didn't allow for updating book or chargeback transactions due to incorrect url
[https://docs.unit.co/transactions#update-transaction-tags](url)
[https://docs.unit.co/transactions#update-book-transaction](url)
[https://docs.unit.co/transactions#update-chargeback-transaction](url)