### PR TITLE
Add card authorization simulations

### DIFF
--- a/resources/simulations.ts
+++ b/resources/simulations.ts
@@ -8,6 +8,9 @@ import {
     CreateAchReceivedPaymentSimulation,
     ReceiveAchPaymentSimulation,
     CreateCardPurchaseSimulation,
+    CreateCardAuthorizationSimulation,
+    IncreaseCardAuthorizationSimulation,
+    CancelCardAuthorizationSimulation,
     CardTransaction,
 } from "../types"
 
@@ -103,5 +106,37 @@ export class Simulations extends BaseResource {
         return this.httpPost<UnitResponse<CardTransaction>>("/purchases", {
             data: request,
         })
+    }
+
+    public async createCardAuthorization(
+        request: CreateCardAuthorizationSimulation
+    ): Promise<UnitResponse<CardTransaction>> {
+        return this.httpPost<UnitResponse<CardTransaction>>("/authorizations", {
+            data: request,
+        })
+    }
+    
+    public async increaseCardAuthorization(
+        request: IncreaseCardAuthorizationSimulation,
+        authorizationId: string
+    ): Promise<UnitResponse<CardTransaction>> {
+        return this.httpPost<UnitResponse<CardTransaction>>(
+            `/authorizations/${authorizationId}/increase`,
+            {
+                data: request,
+            }
+        )
+    }
+    
+    public async cancelCardAuthorization(
+        request: CancelCardAuthorizationSimulation,
+        authorizationId: string
+    ): Promise<UnitResponse<CardTransaction>> {
+        return this.httpPost<UnitResponse<CardTransaction>>(
+            `/authorizations/${authorizationId}/cancel`,
+            {
+                data: request,
+            }
+        )
     }
 }

--- a/types/simulations.ts
+++ b/types/simulations.ts
@@ -95,9 +95,39 @@ export interface CreateCardAuthorizationSimulation {
          * The 4-digit ISO 18245 merchant category code (MCC). Use any number (e.g. 1000 for testing).
          */
         merchantType: number
-        merchantLocation: string
+        merchantLocation?: string
+        merchantId?: string
         recurring?: boolean
+        status?: "Authorized" | "Declined"
+    };
+    relationships: {
+        account: {
+            data: {
+                type: "depositAccount"
+                id: string
+            }
+        }
     }
+}
+
+export interface IncreaseCardAuthorizationSimulation {
+    type: "authorization"
+    attributes: {
+        amount: number
+        cardLast4Digits: string
+        recurring: boolean
+    };
+    relationships: {
+        account: {
+            data: {
+                type: "depositAccount"
+                id: string
+            }
+        }
+    }
+}
+
+export interface CancelCardAuthorizationSimulation {
     relationships: {
         account: {
             data: {
@@ -131,6 +161,12 @@ export interface CreateCardPurchaseSimulation {
         account: {
             data: {
                 type: "depositAccount"
+                id: string
+            }
+        }
+        authorization?: {
+            data: {
+                type: "authorization"
                 id: string
             }
         }


### PR DESCRIPTION
This adds these 3 simulation endpoints

```
CreateCardAuthorizationSimulation
IncreaseCardAuthorizationSimulation
CancelCardAuthorizationSimulation
```

`CreateCardAuthorizationSimulation` was already partially in the SDK, but the arguments didn't line up with the docs.