### PR TITLE
Add optional authorization relationship to CardTransaction type

### DIFF
--- a/resources/simulations.ts
+++ b/resources/simulations.ts
@@ -8,6 +8,9 @@ import {
     CreateAchReceivedPaymentSimulation,
     ReceiveAchPaymentSimulation,
     CreateCardPurchaseSimulation,
+    CreateCardAuthorizationSimulation,
+    IncreaseCardAuthorizationSimulation,
+    CancelCardAuthorizationSimulation,
     CardTransaction,
 } from "../types"
 
@@ -103,5 +106,37 @@ export class Simulations extends BaseResource {
         return this.httpPost<UnitResponse<CardTransaction>>("/purchases", {
             data: request,
         })
+    }
+
+    public async createCardAuthorization(
+        request: CreateCardAuthorizationSimulation
+    ): Promise<UnitResponse<CardTransaction>> {
+        return this.httpPost<UnitResponse<CardTransaction>>("/authorizations", {
+            data: request,
+        })
+    }
+    
+    public async increaseCardAuthorization(
+        request: IncreaseCardAuthorizationSimulation,
+        authorizationId: string
+    ): Promise<UnitResponse<CardTransaction>> {
+        return this.httpPost<UnitResponse<CardTransaction>>(
+            `/authorizations/${authorizationId}/increase`,
+            {
+                data: request,
+            }
+        )
+    }
+    
+    public async cancelCardAuthorization(
+        request: CancelCardAuthorizationSimulation,
+        authorizationId: string
+    ): Promise<UnitResponse<CardTransaction>> {
+        return this.httpPost<UnitResponse<CardTransaction>>(
+            `/authorizations/${authorizationId}/cancel`,
+            {
+                data: request,
+            }
+        )
     }
 }

--- a/types/simulations.ts
+++ b/types/simulations.ts
@@ -95,9 +95,39 @@ export interface CreateCardAuthorizationSimulation {
          * The 4-digit ISO 18245 merchant category code (MCC). Use any number (e.g. 1000 for testing).
          */
         merchantType: number
-        merchantLocation: string
+        merchantLocation?: string
+        merchantId?: string
         recurring?: boolean
+        status?: "Authorized" | "Declined"
+    };
+    relationships: {
+        account: {
+            data: {
+                type: "depositAccount"
+                id: string
+            }
+        }
     }
+}
+
+export interface IncreaseCardAuthorizationSimulation {
+    type: "authorization"
+    attributes: {
+        amount: number
+        cardLast4Digits: string
+        recurring: boolean
+    };
+    relationships: {
+        account: {
+            data: {
+                type: "depositAccount"
+                id: string
+            }
+        }
+    }
+}
+
+export interface CancelCardAuthorizationSimulation {
     relationships: {
         account: {
             data: {
@@ -131,6 +161,12 @@ export interface CreateCardPurchaseSimulation {
         account: {
             data: {
                 type: "depositAccount"
+                id: string
+            }
+        }
+        authorization?: {
+            data: {
+                type: "authorization"
                 id: string
             }
         }

--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -586,6 +586,10 @@ export type CardTransaction = BaseTransaction & {
          * The debit card involved in the transaction.
          */
         card: Relationship
+        /**
+         * Optional. The [Authorization](https://developers.unit.co/#authorization) request made by the merchant, if present (see [Authorizations](https://developers.unit.co/#authorizations)).
+         */
+        authorization?: Relationship
     } & BaseTransactionRelationships
 }
 


### PR DESCRIPTION
This has 2 commits because I'm using it on top of [my other PR](https://github.com/unit-finance/unit-node-sdk/pull/381).

If the other PR gets merged in I can rebase this so it just shows one commit.

I have confirmed in production that this `authorization` relationship can be present. [It's also shown in the docs.](https://docs.unit.co/resources/#transaction-card)

<img width="576" alt="Screenshot 2023-09-17 at 8 42 54 PM" src="https://github.com/unit-finance/unit-node-sdk/assets/8979400/55bade2e-7d94-45ef-af53-95be486efd2d">
