### PR TITLE
Add name and website to rich merchant type

### DIFF
--- a/types/common.ts
+++ b/types/common.ts
@@ -426,6 +426,8 @@ export type EntityType = "Corporation" | "LLC" | "Partnership" | "PubliclyTraded
 
 
 export interface RichMerchantData {
+    name: string;
+    website?: string;
     logo?: string // URL of the merchant's logo.
     phone?: string // Phone number of the merchant.
     categories?: Array<{ name: string; icon: string; }> // Array of categories the merchant belongs to (from the least specific to the most specific).


### PR DESCRIPTION
Added `name` and optional `website` to the types so they [line up with the Unit docs](https://docs.unit.co/types#rich-merchant-data)