### PR TITLE
Add atm transaction card network

### DIFF
--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -482,6 +482,11 @@ export type AtmTransaction = BaseTransaction & {
         grossInterchange?: string
 
         /**
+         * Optional. The card network used.
+         */
+        cardNetwork?: "Visa" | "Interlink" | "Accel" | "Allpoint" | "Other"
+
+        /**
          * Optional. When original currency for transaction is not USD.
          */
         currencyConversion?: CurrencyConversion


### PR DESCRIPTION
Added the optional `cardNetwork` field to line up ATM Transaction with [the Unit docs](https://docs.unit.co/resources/#transaction-atm)