### PR TITLE
Add unit error payload meta field existingIds

### DIFF
--- a/types/common.ts
+++ b/types/common.ts
@@ -514,8 +514,11 @@ export interface UnitErrorPayload {
     code?: string
     detail?: string // to be deprecated
     details?: string
-    meta?: { supportId?: string; }
-    source?: { pointer: string; }
+    meta?: {
+        supportId?: string
+        existingIds?: string[]
+    }
+    source?: { pointer: string }
     [k: string]: unknown // allow for other keys
 }
 


### PR DESCRIPTION
field is also missing from the Unit Docs: https://docs.unit.co/about-jsonapi/#intro-errors