### PR TITLE
Update CI-appsec-blackduck-master.yml

### DIFF
--- a/.github/workflows/CI-appsec-blackduck-master.yml
+++ b/.github/workflows/CI-appsec-blackduck-master.yml
@@ -4,6 +4,12 @@ on:
     #At 13:00 on every day-of-week from Sunday through Thursday.
     - cron: '0 13 * * SUN-THU'
   workflow_dispatch:
+  #The workflow will only run when a push that includes a change to the package.json file is made in the main branch.
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
 
 jobs:
   blackduck-scan:


### PR DESCRIPTION
I noticed that the rapid scanning process of BlackDuck PR can fail if a new unit-node-sdk version is released before a full scan is completed. To address this issue, we are including an additional auto-trigger to the full scan workflow: This new trigger will run a full scan when a push is made in the main branch and there is a change to the package.json file.