### PR TITLE
expose language in get statement api endpoint 

### DIFF
--- a/resources/statements.ts
+++ b/resources/statements.ts
@@ -20,17 +20,18 @@ export class Statments extends BaseResource {
         return this.httpGet<UnitResponse<Statement[]>>("", { params: parameters })
     }
 
-    public get(statementId: string, customerId?: string, isPDF = false, responseEncoding: responseEncoding = "binary"): Promise<string> {
+    public get(statementId: string, customerId?: string, isPDF = false, responseEncoding: responseEncoding = "binary", language: "en" | "es" = "en"): Promise<string> {
         const parameters = {
-            ...(customerId && { "filter[customerId]": customerId })
+            ...(customerId && { "filter[customerId]": customerId }),
+            language: language
         }
 
         const url = isPDF ? `/${statementId}/pdf` : `/${statementId}/html`
         return this.httpGet<string>(url, {params: parameters, responseEncoding})
     }
 
-    public getBinary(statementId: string, customerId?: string, isPDF = false): Promise<string> {
-        return this.get(statementId, customerId, isPDF)
+    public getBinary(statementId: string, customerId?: string, isPDF = false, language: "en" | "es" = "en"): Promise<string> {
+        return this.get(statementId, customerId, isPDF, language)
     }
 
     public getBankVerification(accountId: string, includeProofOfFunds = false, responseEncoding: responseEncoding = "binary", responseType: ResponseType = "blob"): Promise<string> {


### PR DESCRIPTION
get statement pdf/html API can have language passed in as parameter -- be it `es` or `en` for spanish / english. let's expose this in the `statements.ts` file to let folks get statements either on spanish or english. 

adding an optional `language` parameter which defaults to `en` and passes it as a parameter to the this.httpGet call .

https://docs.unit.co/statements#get-statement-pdf 

noticed this was suggested from https://github.com/unit-finance/unit-node-sdk/pull/107 over a year ago. would be great to  add as a non breaking change before changing to a parameters dict in the call.