### PR TITLE
Adjust authorization declined event properties so they line up with the Unit docs

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -122,6 +122,7 @@ export type AuthorizationCanceled = BaseEvent & {
 export type AuthorizationDeclined = BaseEvent & {
     type: "authorization.declined"
     attributes: {
+        merchant: Merchant
         reason: string
     } & AuthorizationAttributes
     relationships: AuthorizationRelationships


### PR DESCRIPTION
1 line change.

The [declined properties](https://docs.unit.co/events#authorizationdeclined) are all the same as [authorization created in the docs](https://docs.unit.co/events/#authorizationcreated) except there is another `reason: string`

So this PR just copy/pastes the merchant attributes from the authorization created event right above.