### PR TITLE
Adding BankRepaymentTransaction type

### DIFF
--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -2,7 +2,7 @@ import { Address, CardNetwork, Coordinates, Counterparty, CurrencyConversion, Di
 
 export type Transaction = OriginatedAchTransaction | ReceivedAchTransaction | ReturnedAchTransaction | ReturnedReceivedAchTransaction | DishonoredAchTransaction | BookTransaction | PurchaseTransaction | AtmTransaction | FeeTransaction |
     CardReversalTransaction | CardTransaction | WireTransaction | ReleaseTransaction | AdjustmentTransaction | InterestTransaction | DisputeTransaction | CheckDepositTransaction | ReturnedCheckDepositTransaction | PaymentAdvanceTransaction |
-    RepaidPaymentAdvanceTransaction | PaymentCanceledTransaction | RewardTransaction | NegativeBalanceCoverageTransaction | PushToCardTransaction | AccountLowBalanceClosureTransaction
+    RepaidPaymentAdvanceTransaction | PaymentCanceledTransaction | RewardTransaction | NegativeBalanceCoverageTransaction | PushToCardTransaction | AccountLowBalanceClosureTransaction | BankRepaymentTransaction
 
 export interface BaseTransaction {
     /**
@@ -893,6 +893,7 @@ export type AccountLowBalanceClosureTransaction = BaseTransaction & {
         receiverAccount: Relationship
     }
 }
+
 export type NegativeBalanceCoverageTransaction = BaseTransaction & {
     type: "negativeBalanceCoverageTransaction"
 }
@@ -941,3 +942,25 @@ export type PatchTransactionWithRelationshipsRequest = {
     }
 }
 
+export type BankRepaymentTransaction = BaseTransaction & {
+    type: "bankRepaymentTransaction"
+
+    attributes: {
+        /**
+         * The date for which the transaction is applied.
+         */
+        paidForDate: string
+    } & BaseTransactionAttributes;
+
+    relationships: {
+        /**
+         * The org the customer belongs to.
+         */
+        org?: Relationship
+
+        /**
+         * The account that received the funds.
+         */
+        receivingAccount?: Relationship
+    } & BaseTransactionRelationships;
+}


### PR DESCRIPTION
Adding `BankRepaymentTransaction` to the list of `Transaction` types based on the following response from Unit's API:

```
{
            "type": "bankRepaymentTransaction",
            "id": "5557104",
            "attributes": {
                "createdAt": "2023-10-11T06:56:00.045Z",
                "paidForDate": "231010",
                "amount": 1100,
                "direction": "Debit",
                "balance": 5016582,
                "summary": "Bank repayment from 1560118 to 1560116 for day 2023-10-10"
            },
            "relationships": {
                "account": {
                    "data": {
                        "type": "account",
                        "id": "1560118"
                    }
                },
                "customer": {
                    "data": {
                        "type": "customer",
                        "id": "1104057"
                    }
                },
                "customers": {
                    "data": [
                        {
                            "type": "customer",
                            "id": "1104057"
                        }
                    ]
                },
                "org": {
                    "data": {
                        "type": "org",
                        "id": "403"
                    }
                },
                "receivingAccount": {
                    "data": {
                        "type": "account",
                        "id": "1560116"
                    }
                }
            }
        }
```

Basically this PR is using existing transaction types structure and adding a new one.