### PR TITLE
Add missing link and disputeType fields to Dispute object

### DIFF
--- a/types/dispute.ts
+++ b/types/dispute.ts
@@ -58,6 +58,11 @@ export interface Dispute {
         amount: number
 
         /**
+         * Optional. Reason for a ResolvedLost status.
+         */
+        decisionReason?: string
+
+        /**
          * Optional. Link to the dispute.
          */
         link?: string

--- a/types/dispute.ts
+++ b/types/dispute.ts
@@ -58,9 +58,14 @@ export interface Dispute {
         amount: number
 
         /**
-         * Optional. Reason for a ResolvedLost status.
+         * Optional. Link to the dispute.
          */
-        decisionReason?: string
+        link?: string
+
+        /**
+         * Optional. The type of dispute.
+         */
+        disputeType?: string
     }
 
     /**


### PR DESCRIPTION
The `Dispute` object is missing the `link` and `disputeType` fields despite these being received from our Unit payloads. 

https://docs.unit.co/resources#dispute