### PR TITLE
Update relationships for RepaymentStatusChanged Event

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -841,8 +841,8 @@ export type RepaymentStatusChanged = BaseEvent & {
         previousStatus: string
     }
     relationships: BaseEventRelationships & {
-        dispute: Relationship
-        transaction: Relationship
+        repayment: Relationship
+        payment: Relationship
     }
 }
 


### PR DESCRIPTION
## Context
- I believe the relationships for `dispute events` were accidentally copied over for `repayment events`. 
- This PR simply updates `RepaymentStatusChanged` event to have the correct relationships.

|From current SDK| From Docs|
|--|--|
|![Screenshot 2023-12-11 at 2 16 07 PM](https://github.com/unit-finance/unit-node-sdk/assets/9409848/7537235e-2d80-483d-98a6-a4fab15c54ac)|![Screenshot 2023-12-11 at 2 21 13 PM](https://github.com/unit-finance/unit-node-sdk/assets/9409848/db876312-5015-4790-a0ab-29370684c864)|
