### PR TITLE
Update state to be required for US addresses

### DIFF
--- a/types/common.ts
+++ b/types/common.ts
@@ -81,7 +81,7 @@ export interface UsAddress {
     /**
      * Two letters representing the state. Only required for US addresses.
      */
-    state?: State
+    state: State
 
     /**
      * Postal code.


### PR DESCRIPTION
State should be required for US addresses. Updated type to account for this. 