### PR TITLE
fix: Search ATM locations

### DIFF
--- a/resources/atmLocations.ts
+++ b/resources/atmLocations.ts
@@ -10,8 +10,8 @@ export class AtmLocations extends BaseResource {
 
     public async list(params?: AtmLocationListParams): Promise<UnitResponse<AtmLocation[]>> {
         const parameters = {
-            ...(params?.coordinates && { "filter[coordinates]": params.coordinates }),
-            ...(params?.address && { "filter[address]": params.address }),
+            ...(params?.coordinates && { "filter[coordinates]": JSON.stringify(params.coordinates) }),
+            ...(params?.address && { "filter[address]": JSON.stringify(params.address) }),
             ...(params?.postalCode && { "filter[postalCode]": params.postalCode }),
             ...(params?.searchRadius && { "filter[searchRadius]": params.searchRadius })
         }

--- a/tests/atmLocations.spec.ts
+++ b/tests/atmLocations.spec.ts
@@ -1,0 +1,16 @@
+import { Unit } from "../unit"
+
+import dotenv from "dotenv"
+dotenv.config()
+const unit = new Unit(process.env.UNIT_TOKEN || "test", process.env.UNIT_API_URL || "test")
+
+describe("Get ATM Locations", () => {
+    test("Get ATM Locations by coordinates",async () => {
+        const res = await unit.atmLocations.list({coordinates: {longitude: -73.93041, latitude: 42.79894}})
+        
+        res.data.forEach(element => {
+            console.log(element)
+            expect(element.type).toBe("atmLocation")
+        })
+    })
+})

--- a/tests/atmLocations.spec.ts
+++ b/tests/atmLocations.spec.ts
@@ -12,4 +12,12 @@ describe("Get ATM Locations", () => {
             expect(element.type).toBe("atmLocation")
         })
     })
+
+    test("Get ATM Locations by address",async () => {
+        const res = await unit.atmLocations.list({address: {"street":"1240 EASTERN AVE", "city":"SCHENECTADY", "state":"NY", "postalCode":"", "country":"US"}})
+        
+        res.data.forEach(element => {
+            expect(element.type).toBe("atmLocation")
+        })
+    })
 })

--- a/tests/atmLocations.spec.ts
+++ b/tests/atmLocations.spec.ts
@@ -7,9 +7,8 @@ const unit = new Unit(process.env.UNIT_TOKEN || "test", process.env.UNIT_API_URL
 describe("Get ATM Locations", () => {
     test("Get ATM Locations by coordinates",async () => {
         const res = await unit.atmLocations.list({coordinates: {longitude: -73.93041, latitude: 42.79894}})
-        
+
         res.data.forEach(element => {
-            console.log(element)
             expect(element.type).toBe("atmLocation")
         })
     })

--- a/types/common.ts
+++ b/types/common.ts
@@ -230,12 +230,12 @@ export interface Coordinates {
     /**
      * The longitude value.
      */
-    longitude: number
+    longitude: number | string
 
     /**
      * The latitude value.
      */
-    latitude: number
+    latitude: number | string
 }
 
 export interface Statement {


### PR DESCRIPTION
Because of the changes axios made, we should use JSON.stringify when sending objects as params

thanks: @Physicliar
https://github.com/unit-finance/unit-node-sdk/issues/435