### PR TITLE
Support dba as an optional field to PatchBusinessCustomerRequest

### DIFF
--- a/types/customer.ts
+++ b/types/customer.ts
@@ -293,6 +293,11 @@ export interface PatchBusinessCustomerRequest {
             phone?: Phone
 
             /**
+             * To modify or add specify the new dba name of the business.
+             */
+            dba?: string
+
+            /**
              * Primary contact of the business.
              */
             contact?: BusinessContact


### PR DESCRIPTION
As indicated in the [document](https://www.unit.co/docs/api/customers/#update-business-customer), we should be able to update a `dba` field for a `businessCustomer`. However, the SDK does not yet support this field in the `PatchBusinessCustomerRequest'`interface.


I have also verified that the API does indeed allow dba to be updated for a `businessCustomer`
![image](https://github.com/unit-finance/unit-node-sdk/assets/9467678/a3ef87c6-d7b3-4a5b-9341-149d03aecc69)
