### PR TITLE
Make rejectReason optional

### DIFF
--- a/types/rewards.ts
+++ b/types/rewards.ts
@@ -41,7 +41,7 @@ export interface Reward {
         /**
          * Optional. More information about the status.
          */
-        rejectReason: string
+        rejectReason?: string
 
         /**
          * See [Tags](https://developers.unit.co/#tags).


### PR DESCRIPTION
The description says optional but the return field is not - was this a typo or intended? 

Feel free to take this over. 