### PR TITLE
Update CreateStopPaymentRequest type to match docs

### DIFF
--- a/types/checkPayment.ts
+++ b/types/checkPayment.ts
@@ -187,9 +187,10 @@ export interface CheckPayment {
 export interface CreateStopPaymentRequest {
     type: "stopPayment"
     attributes: {
-        amount: number
+        amount?: number
         checkNumber: string
         tags: Tags
+        idempotencyKey?: string
     }
     relationships: {
         account: Relationship


### PR DESCRIPTION
There seems to be a mismatch between the [docs](https://www.unit.co/docs/api/stop-payments/#create-check-stop-payment) and the request typing in the sdk for the create-check-stop-payment endpoint.