### PR TITLE
Add sameDay param to recurringCreditAchPayment

### DIFF
--- a/types/recurringPayment.ts
+++ b/types/recurringPayment.ts
@@ -216,6 +216,11 @@ export interface CreateRecurringCreditAchPaymentRequest {
          * Optional, additional payment description (maximum of 50 characters), not all institutions present that.
          */
         addenda?: string
+
+        /**
+         * Optional, default is false. See Same Day ACH.
+         */
+        sameDay?: boolean
     } & CreateRecurringRequestAttributes
 
     /**


### PR DESCRIPTION
It's not documented but it should exist? Can the Unit team verify

https://www.unit.co/docs/api/recurring-payments/#recurring-payment-credit-ach-payment