### PR TITLE
Add gross interchange to transaction.updated type

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -464,6 +464,7 @@ export type TransactionUpdated = BaseEvent & {
     type: "transaction.updated"
     attributes: {
         interchange: number
+        grossInterchange: number
     }
     relationships: {
         transaction: Relationship


### PR DESCRIPTION
Just added one field to match the [payload in the Unit docs](https://www.unit.co/docs/api/events/#transactionupdated)