### PR TITLE
Add fields to payment created event

### DIFF
--- a/types/events.ts
+++ b/types/events.ts
@@ -343,6 +343,8 @@ export type PaymentCreated = BaseEvent & {
     type: "payment.created"
     attributes: {
         status: string
+        amount: number
+        direction: Direction
     }
     relationships: PaymentRelationships
 }


### PR DESCRIPTION
These match what I've seen returned from the Unit API and from the docs https://www.unit.co/docs/api/events/#paymentcreated

```
{
  id: '32564793',
  type: 'payment.created',
  attributes: {
    createdAt: '2024-08-30T23:41:34.526Z',
    status: 'Pending',
    amount: 1000,
    direction: 'Debit',
    tags: {}
  },
  relationships: {
    payment: { data: { id: '5191197', type: 'payment' } },
    account: { data: { id: '4091231', type: 'account' } },
    customer: { data: { id: '2321226', type: 'customer' } }
  }
}
```