### PR TITLE
add type and resource for the repayment-information endpoint

### DIFF
--- a/resources/account.ts
+++ b/resources/account.ts
@@ -8,7 +8,8 @@ import {
     AccountDepositProduct,
     CloseAccountRequest,
     FreezeAccountRequest,
-    AccountOwnersRequest
+    AccountOwnersRequest,
+    RepaymentInformation
 } from "../types/account"
 import {BaseResource} from "./baseResource"
 
@@ -97,6 +98,10 @@ export class Accounts extends BaseResource {
 
     public async deactivateDaca(accountId: string): Promise<UnitResponse<Account>> {
         return this.httpGet<UnitResponse<Account>>(`/${accountId}/deactivate-daca`)
+    }
+
+    public async getRepaymentInformation(accountId: string): Promise<UnitResponse<RepaymentInformation>> {
+        return this.httpGet<UnitResponse<RepaymentInformation>>(`/${accountId}/repayment-information`)
     }
 }
 

--- a/types/account.ts
+++ b/types/account.ts
@@ -170,6 +170,36 @@ export interface CreditAccount {
     } & UnimplementedFields
 }
 
+export interface RepaymentInformation {
+    type: "creditAccountRepaymentInformation",
+    attributes: {
+        /**
+         * The amount (cents) of the total amount due, including the remainingAmountOverdue.
+         */
+        remainingAmountDue: number
+        /**
+         * The amount (cents) of the amount overdue for the current payment period.
+         */
+        remainingAmountOverdue: number
+        /**
+         * The number of repayments that have been initiated but not yet settled to a final state.
+         */
+        initiatedRepayments: number
+        /**
+         * The start date in YYYY-MM-DD format for the current statement period.
+         */
+        statementPeriodStart: string
+        /**
+         * The end date in YYYY-MM-DD format for the current statement period.
+         */
+        statementPeriodEnd: string
+        /**
+         * The date in YYYY-MM-DD format for the expected repayment for the statement period start and end.
+         */
+        nextRepaymentDueDate: string
+    }
+}
+
 export type CreateAccountRequest = CreateDepositAccountRequest | CreateBatchAccountRequest | CreateCreditAccountRequest
 
 export interface CreateDepositAccountRequest {


### PR DESCRIPTION
hopefully a non invasive add - wanted to include the endpoint in the docs with the unit sdk we are using for the charge card program - https://www.unit.co/docs/api/credit-accounts/#account-repayment-information

let me know if there's something im missing, thanks!