### PR TITLE
add export to credit application status

### DIFF
--- a/types/creditApplication.ts
+++ b/types/creditApplication.ts
@@ -1,7 +1,7 @@
 import { NumberOfEmployees } from "./application"
 import { Relationship } from "./common"
 
-type CreditApplicationStatus = "Created" | "Pending" | "Approved" | "Denied" | "Canceled"
+export type CreditApplicationStatus = "Created" | "Pending" | "Approved" | "Denied" | "Canceled"
 
 interface CreditApplicationAttributes {
     /**


### PR DESCRIPTION
allow the export of status - on our side we map status codes to a generic lower cased form, across vendors for applications.  QoL improvement if we can export this, and map.