### PR TITLE
Add auth typing to atm transactions

### DIFF
--- a/types/transactions.ts
+++ b/types/transactions.ts
@@ -500,6 +500,11 @@ export type AtmTransaction = BaseTransaction & {
          * The debit card involved in the transaction.
          */
         card: Relationship
+
+        /**
+         * Optional. The [Authorization](https://developers.unit.co/#authorization) request made by the merchant, if present (see [Authorizations](https://developers.unit.co/#authorizations)).
+         */
+        authorization?: Relationship
     }
 }
 


### PR DESCRIPTION
This is a real field that I encountered on a production payload. Adding the type here.

<img width="293" alt="Screenshot 2025-05-04 at 8 40 58 PM" src="https://github.com/user-attachments/assets/5441ad5a-a0e8-4921-a04b-84d718ec2f2d" />
