### PR TITLE
Fix: add archived property to ApplicationDocument interface

### DIFF
--- a/types/application.ts
+++ b/types/application.ts
@@ -523,6 +523,11 @@ export interface ApplicationDocument {
          * Application Document rejection reason. Present only when document status is Invalid.
          */
         reason?: string
+
+        /**
+         * Indicates whether the document has been archived. Archived documents are read-only and no changes can be made to them.
+         */
+        archived: boolean
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the `archived` type to the document types to help developers identify and filter out archived documents when working with Unit's API.

## Problem
When pulling documents from Unit, archived documents are being listed alongside active documents, which can lead to duplicate documents with different statuses. Previously, there was no way to identify archived documents as the `archived` type was not defined in the types.

## Solution
Added the `archived` type to the document types, making it clear to developers that this type exists and can be used for filtering.

## Impact
- Developers can now identify archived documents
- Prevents confusion with duplicate documents
- Enables proper filtering of archived documents when needed
