### PR TITLE
Add daily and monthly CardTransaction limits to CardLevelLimits

### DIFF
--- a/types/cards.ts
+++ b/types/cards.ts
@@ -460,8 +460,10 @@ export interface PinStatus {
 export interface CardLevelLimits {
     dailyWithdrawal?: number
     dailyPurchase?: number
+    dailyCardTransaction?: number
     monthlyWithdrawal?: number
     monthlyPurchase?: number
+    monthlyCardTransaction?: number
 }
 
 export interface CardLimits {


### PR DESCRIPTION
This just adjusts the types to match Unit's new [Card Limits Update](https://www.unit.co/docs/api/cards/apis/#card-limits)