### PR TITLE
UD-17432: version bump to 1.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unit-finance/unit-node-sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@unit-finance/unit-node-sdk",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MPLv2",
       "dependencies": {
         "axios": "^1.8.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unit-finance/unit-node-sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "",
   "main": "dist/unit.js",
   "types": "dist/unit.d.ts",


### PR DESCRIPTION
## Summary
- Bump `@unit-finance/unit-node-sdk` from `1.4.3` to `1.4.4` to publish the `MerchantCashAdvance` Product type change from #553

## Test plan
- [ ] Merge to `main` to trigger npm publish workflow
- [ ] Verify `1.4.4` is published to npm


Made with [Cursor](https://cursor.com)